### PR TITLE
Improve filter

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -97,7 +97,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "infoPasswordResetEmailSent" : MessageLookupByLibrary.simpleMessage("Please check your inbox for the password reset e-mail."),
     "infoRelevance" : MessageLookupByLibrary.simpleMessage("Try to choose the most restrictive category."),
     "infoRelevanceExample" : MessageLookupByLibrary.simpleMessage("For instance, if something is only relevant for \"314CB\" and \"315CB\", don\'t just set \"CB\"."),
-    "infoRelevanceNothingSelected" : MessageLookupByLibrary.simpleMessage("Don\'t select anything if this is relevant for everyone."),
+    "infoRelevanceNothingSelected" : MessageLookupByLibrary.simpleMessage("If this is relevant for everyone, don\'t select anything ."),
     "labelCategory" : MessageLookupByLibrary.simpleMessage("Category"),
     "labelClass" : MessageLookupByLibrary.simpleMessage("Class"),
     "labelColor" : MessageLookupByLibrary.simpleMessage("Color"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -97,6 +97,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "infoPasswordResetEmailSent" : MessageLookupByLibrary.simpleMessage("Please check your inbox for the password reset e-mail."),
     "infoRelevance" : MessageLookupByLibrary.simpleMessage("Try to choose the most restrictive category."),
     "infoRelevanceExample" : MessageLookupByLibrary.simpleMessage("For instance, if something is only relevant for \"314CB\" and \"315CB\", don\'t just set \"CB\"."),
+    "infoRelevanceNothingSelected" : MessageLookupByLibrary.simpleMessage("Don\'t select anything if this is relevant for everyone."),
     "labelCategory" : MessageLookupByLibrary.simpleMessage("Category"),
     "labelClass" : MessageLookupByLibrary.simpleMessage("Class"),
     "labelColor" : MessageLookupByLibrary.simpleMessage("Color"),

--- a/lib/generated/intl/messages_ro.dart
+++ b/lib/generated/intl/messages_ro.dart
@@ -97,6 +97,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "infoPasswordResetEmailSent" : MessageLookupByLibrary.simpleMessage("Please check your inbox for the password reset e-mail."),
     "infoRelevance" : MessageLookupByLibrary.simpleMessage("Încercați să selectați cea mai restrictivă categorie."),
     "infoRelevanceExample" : MessageLookupByLibrary.simpleMessage("De exemplu, dacă ceva este relevant doar pentru \"314CB\" și \"315CB\", nu setați direct \"CB\"."),
+    "infoRelevanceNothingSelected" : MessageLookupByLibrary.simpleMessage("Nu selectați nimic dacă este relevant pentru toată lumea."),
     "labelCategory" : MessageLookupByLibrary.simpleMessage("Categorie"),
     "labelClass" : MessageLookupByLibrary.simpleMessage("Materie"),
     "labelColor" : MessageLookupByLibrary.simpleMessage("Culoare"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1774,10 +1774,10 @@ class S {
     );
   }
 
-  /// `Don't select anything if this is relevant for everyone.`
+  /// `If this is relevant for everyone, don't select anything .`
   String get infoRelevanceNothingSelected {
     return Intl.message(
-      'Don\'t select anything if this is relevant for everyone.',
+      'If this is relevant for everyone, don\'t select anything .',
       name: 'infoRelevanceNothingSelected',
       desc: '',
       args: [],

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,6 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+
 import 'intl/messages_all.dart';
 
 // **************************************************************************
@@ -1758,6 +1759,16 @@ class S {
     return Intl.message(
       'Try to choose the most restrictive category.',
       name: 'infoRelevance',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Don't select anything if this is relevant for everyone.`
+  String get infoRelevanceNothingSelected {
+    return Intl.message(
+      'Don\'t select anything if this is relevant for everyone.',
+      name: 'infoRelevanceNothingSelected',
       desc: '',
       args: [],
     );

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -188,7 +188,7 @@
 
   "infoPasswordResetEmailSent": "Please check your inbox for the password reset e-mail.",
   "infoRelevance": "Try to choose the most restrictive category.",
-  "infoRelevanceNothingSelected": "Don't select anything if this is relevant for everyone.",
+  "infoRelevanceNothingSelected": "If this is relevant for everyone, don't select anything .",
   "infoRelevanceExample": "For instance, if something is only relevant for \"314CB\" and \"315CB\", don't just set \"CB\".",
   "infoPassword": "It must contain lower and uppercase letters, one number and one special character, and have a minimum length of 8.",
   "infoAppIsOpenSource": "ACS UPB Mobile is open source.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -187,6 +187,7 @@
 
   "infoPasswordResetEmailSent": "Please check your inbox for the password reset e-mail.",
   "infoRelevance": "Try to choose the most restrictive category.",
+  "infoRelevanceNothingSelected": "Don't select anything if this is relevant for everyone.",
   "infoRelevanceExample": "For instance, if something is only relevant for \"314CB\" and \"315CB\", don't just set \"CB\".",
   "infoPassword": "It must contain lower and uppercase letters, one number and one special character, and have a minimum length of 8.",
   "infoAppIsOpenSource": "ACS UPB Mobile is open source.",

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -187,6 +187,7 @@
 
   "infoPasswordResetEmailSent": "Please check your inbox for the password reset e-mail.",
   "infoRelevance": "Încercați să selectați cea mai restrictivă categorie.",
+  "infoRelevanceNothingSelected": "Nu selectați nimic dacă este relevant pentru toată lumea.",
   "infoRelevanceExample": "De exemplu, dacă ceva este relevant doar pentru \"314CB\" și \"315CB\", nu setați direct \"CB\".",
   "infoPassword": "Aceasta trebuie să conțină majuscule, minuscule și cel puțin un număr sau un simbol, având minimum 8 caractere.",
   "infoAppIsOpenSource": "ACS UPB Mobile este open source.",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:acs_upb_mobile/navigation/bottom_navigation_bar.dart';
 import 'package:acs_upb_mobile/navigation/routes.dart';
 import 'package:acs_upb_mobile/pages/classes/service/class_provider.dart';
 import 'package:acs_upb_mobile/pages/filter/service/filter_provider.dart';
-import 'package:acs_upb_mobile/pages/filter/view/filter_page.dart';
 import 'package:acs_upb_mobile/pages/portal/service/website_provider.dart';
 import 'package:acs_upb_mobile/pages/settings/settings_page.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
@@ -66,7 +65,6 @@ class _MyAppState extends State<MyApp> {
         Routes.root: (_) => AppLoadingScreen(),
         Routes.home: (_) => AppBottomNavigationBar(),
         Routes.settings: (_) => SettingsPage(),
-        Routes.filter: (_) => FilterPage(),
         Routes.login: (_) => LoginView(),
         Routes.signUp: (_) => SignUpView(),
       },

--- a/lib/pages/filter/model/filter.dart
+++ b/lib/pages/filter/model/filter.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/cupertino.dart';
 
 /// Filter represented in the form of a tree with named levels
 ///
@@ -27,21 +27,16 @@ class Filter {
   /// Name of each level of the tree.
   ///
   /// **Note:** There should be at least as many names as there are levels in the tree.
-  List<Map<String, String>> localizedLevelNames;
+  final List<Map<String, String>> localizedLevelNames;
 
-  Filter({this.root, this.localizedLevelNames, void Function() listener}) {
+  Filter({this.root, this.localizedLevelNames}) {
     this.root.value = true; // root value is true by default
-    _addListener(listener ?? () {}, this.root);
   }
 
-  static _addListener(void Function() listener, FilterNode node) {
-    node._valueNotifier.addListener(listener);
-    if (node.children != null) {
-      for (var child in node.children) {
-        _addListener(listener, child);
-      }
-    }
-  }
+  Filter clone() => Filter(
+        root: this.root.clone(),
+        localizedLevelNames: this.localizedLevelNames,
+      );
 
   void _relevantNodesHelper(List<String> list, FilterNode node) {
     if (node.value) {
@@ -167,4 +162,12 @@ class FilterNode {
   get value => _valueNotifier.value;
 
   set value(bool value) => _valueNotifier.value = value;
+
+  set listener(Function() listener) => _valueNotifier.addListener(listener);
+
+  FilterNode clone() => FilterNode(
+    name: name,
+    value: value,
+    children: children?.map((c) => c.clone())?.toList(),
+  );
 }

--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -29,14 +29,15 @@ class FilterProvider with ChangeNotifier {
 
   bool _enabled;
   List<String> _relevantNodes;
+  final List<String> defaultRelevance;
 
   FilterProvider(
       {this.global = false,
       bool filterEnabled,
       this.defaultDegree,
-      List<String> defaultRelevance})
-      : _enabled = filterEnabled ?? PrefService.get('relevance_filter') ?? true,
-        _relevantNodes = defaultRelevance {
+      this.defaultRelevance})
+      : _enabled =
+            filterEnabled ?? PrefService.get('relevance_filter') ?? true {
     if (defaultRelevance != null) {
       if (this.defaultDegree == null) {
         throw ArgumentError(
@@ -119,9 +120,12 @@ class FilterProvider with ChangeNotifier {
         root: FilterNodeExtension.fromMap(root, 'All'),
       );
 
-      if (_relevantNodes != null && defaultDegree != null) {
+      if (_relevantNodes == null && defaultRelevance != null) {
+        _relevantNodes = defaultRelevance;
         _relevantNodes.forEach((node) =>
             _relevanceFilter.setRelevantUpToRoot(node, defaultDegree));
+      } else if (_relevantNodes != null) {
+        _relevanceFilter.setRelevantNodes(_relevantNodes);
       } else {
         // No previous setting or defaults => set the user's group
         AuthProvider authProvider =

--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -38,7 +38,7 @@ class FilterProvider with ChangeNotifier {
       this.defaultRelevance})
       : _enabled =
             filterEnabled ?? PrefService.get('relevance_filter') ?? true {
-    if (defaultRelevance != null) {
+    if (defaultRelevance != null && !defaultRelevance.contains('All')) {
       if (this.defaultDegree == null) {
         throw ArgumentError(
             'If the relevance is not null, the degree cannot be null.');

--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -76,13 +76,22 @@ class FilterProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void updateFilter(Filter filter) {
+    _relevanceFilter = filter;
+    if (global) {
+      PrefService.setStringList(
+          'relevant_nodes', _relevanceFilter.relevantNodes);
+    }
+    notifyListeners();
+  }
+
   bool get filterEnabled => _enabled;
 
-  Filter get cachedFilter => _relevanceFilter;
+  Filter get cachedFilter => _relevanceFilter.clone();
 
   Future<Filter> fetchFilter(BuildContext context) async {
     if (_relevanceFilter != null) {
-      return _relevanceFilter;
+      return cachedFilter;
     }
 
     try {
@@ -106,15 +115,9 @@ class FilterProvider with ChangeNotifier {
 
       Map<String, dynamic> root = data['root'];
       _relevanceFilter = Filter(
-          localizedLevelNames: levelNames,
-          root: FilterNodeExtension.fromMap(root, 'All'),
-          listener: () {
-            if (global) {
-              PrefService.setStringList(
-                  'relevant_nodes', _relevanceFilter.relevantNodes);
-            }
-            notifyListeners();
-          });
+        localizedLevelNames: levelNames,
+        root: FilterNodeExtension.fromMap(root, 'All'),
+      );
 
       if (_relevantNodes != null && defaultDegree != null) {
         _relevantNodes.forEach((node) =>
@@ -138,7 +141,7 @@ class FilterProvider with ChangeNotifier {
         }
       }
 
-      return _relevanceFilter;
+      return cachedFilter;
     } catch (e, stackTrace) {
       print(e);
       print(stackTrace);

--- a/lib/pages/filter/view/relevance_picker.dart
+++ b/lib/pages/filter/view/relevance_picker.dart
@@ -105,7 +105,9 @@ class _RelevancePickerState extends State<RelevancePicker> {
                 child: FilterPage(
                   title: S.of(context).labelRelevance,
                   buttonText: S.of(context).buttonSet,
-                  info: S.of(context).infoRelevance,
+                  info: S.of(context).infoRelevanceNothingSelected +
+                      ' ' +
+                      S.of(context).infoRelevance,
                   hint: S.of(context).infoRelevanceExample,
                   onSubmit: () async {
                     // Deselect all options

--- a/lib/pages/portal/model/website.dart
+++ b/lib/pages/portal/model/website.dart
@@ -59,7 +59,7 @@ class Website {
         this.label = toString(label).isEmpty ? labelFromLink(link) : label,
         this.link = link,
         this.infoByLocale = infoByLocale ?? {} {
-    if (this.relevance != null) {
+    if (this.relevance != null && !this.relevance.contains('All')) {
       if (this.degree == null) {
         throw ArgumentError(
             'If the relevance is not null, the degree cannot be null.');

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -213,8 +213,6 @@ class _PortalPageState extends State<PortalPage>
 
   @override
   Widget build(BuildContext context) {
-    print('build');
-
     WebsiteProvider websiteProvider = Provider.of<WebsiteProvider>(context);
     filterProvider = Provider.of<FilterProvider>(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context);

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -104,7 +104,7 @@ class _PortalPageState extends State<PortalPage>
                     builder: (_) => ChangeNotifierProvider<FilterProvider>(
                       create: (_) => FilterProvider(
                           defaultDegree: website.degree,
-                          defaultRelevance: website.relevance),
+                          defaultRelevance: website.relevance ?? ['All']),
                       child: WebsiteView(
                         website: website,
                         updateExisting: true,

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -4,9 +4,9 @@ import 'dart:math';
 import 'package:acs_upb_mobile/authentication/model/user.dart';
 import 'package:acs_upb_mobile/authentication/service/auth_provider.dart';
 import 'package:acs_upb_mobile/generated/l10n.dart';
-import 'package:acs_upb_mobile/navigation/routes.dart';
 import 'package:acs_upb_mobile/pages/filter/model/filter.dart';
 import 'package:acs_upb_mobile/pages/filter/service/filter_provider.dart';
+import 'package:acs_upb_mobile/pages/filter/view/filter_page.dart';
 import 'package:acs_upb_mobile/pages/portal/model/website.dart';
 import 'package:acs_upb_mobile/pages/portal/service/website_provider.dart';
 import 'package:acs_upb_mobile/pages/portal/view/website_view.dart';
@@ -33,6 +33,7 @@ class _PortalPageState extends State<PortalPage>
     with AutomaticKeepAliveClientMixin {
   Filter filterCache;
   List<Website> websites = [];
+  FilterProvider filterProvider;
 
   // Only show user-added websites
   bool userOnly = false;
@@ -64,7 +65,7 @@ class _PortalPageState extends State<PortalPage>
       updating = true;
     }
 
-    FilterProvider filterProvider =
+    FilterProvider filterProvider = this.filterProvider ??
         Provider.of<FilterProvider>(context, listen: false);
     filterCache = await filterProvider.fetchFilter(context);
 
@@ -212,10 +213,10 @@ class _PortalPageState extends State<PortalPage>
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
+    print('build');
 
     WebsiteProvider websiteProvider = Provider.of<WebsiteProvider>(context);
-    FilterProvider filterProvider = Provider.of<FilterProvider>(context);
+    filterProvider = Provider.of<FilterProvider>(context);
     AuthProvider authProvider = Provider.of<AuthProvider>(context);
 
     CircularProgressIndicator progressIndicator = CircularProgressIndicator();
@@ -254,9 +255,15 @@ class _PortalPageState extends State<PortalPage>
           tooltip: S.of(context).navigationFilter,
           items: {
             S.of(context).filterMenuRelevance: () {
-              _updateFilter();
               userOnly = false;
-              Navigator.pushNamed(context, Routes.filter);
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => FilterPage(
+                    onSubmit: _updateFilter,
+                  ),
+                ),
+              );
             },
             S.of(context).filterMenuShowMine: () {
               if (authProvider.isAuthenticatedFromCache &&

--- a/lib/widgets/selectable.dart
+++ b/lib/widgets/selectable.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 class SelectableController {
   _SelectableState _selectableState;
 
-  bool get isSelected => _selectableState?.isSelected;
+  bool get isSelected => _selectableState?._isSelected;
 
   void select() {
-    _selectableState.isSelected = true;
+    if (!isSelected) _selectableState.isSelected = true;
   }
 
   void deselect() {
-    _selectableState.isSelected = false;
+    if (isSelected) _selectableState.isSelected = false;
   }
 }
 
@@ -33,12 +33,17 @@ class Selectable extends StatefulWidget {
 }
 
 class _SelectableState extends State<Selectable> {
-  bool isSelected;
+  bool _isSelected;
+
+  set isSelected(bool newValue) {
+    _isSelected = newValue;
+    setState(() {});
+  }
 
   @override
   void initState() {
     super.initState();
-    isSelected = widget.initiallySelected;
+    _isSelected = widget.initiallySelected;
   }
 
   @override
@@ -47,7 +52,7 @@ class _SelectableState extends State<Selectable> {
 
     return Container(
       decoration: BoxDecoration(
-        color: isSelected
+        color: _isSelected
             ? (widget.disabled
                 ? Theme.of(context).disabledColor
                 : Theme.of(context).accentColor)
@@ -67,9 +72,9 @@ class _SelectableState extends State<Selectable> {
             setState(
               () {
                 if (!widget.disabled) {
-                  isSelected = !isSelected;
+                  _isSelected = !_isSelected;
                 }
-                widget.onSelected(isSelected);
+                widget.onSelected(_isSelected);
               },
             );
           },
@@ -84,7 +89,7 @@ class _SelectableState extends State<Selectable> {
                   fontWeight: FontWeight.w600,
                   fontSize: 12,
                   letterSpacing: 0.27,
-                  color: isSelected
+                  color: _isSelected
                       ? Colors.white
                       : widget.disabled
                           ? Theme.of(context).disabledColor

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A mobile application for students at ACS UPB.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.6.0+1
+version: 0.6.1+1
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Filter improvements:
- fix filter options seemingly not persisting after restart
- only apply filter if the apply button is pressed (before, every listener widget would rebuild each time a filter node was selected)
- fix default relevance on relevance picker being the user's class if the website relevance is null (meaning it should be relevant for everyone, and thus no nodes should be selected)

#5 is unfortunately still not fixed and I have no idea what's causing it.