### PR TITLE
Fix package dependency issues and flaky test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
+          flutter-version: '1.24.x'
           channel: 'beta'
 
       - name: Get packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
+          flutter-version: '1.24.x'
           channel: 'beta'
       - name: Check formattting
         run: |
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
+          flutter-version: '1.24.x'
           channel: 'beta'
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
+          flutter-version: '1.24.x'
           channel: 'beta'
 
       - name: Get packages

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -491,12 +491,12 @@ packages:
     source: hosted
     version: "0.1.0+1"
   intl:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0-nullsafety.2"
   intl_translation:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.0"
   built_collection:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.5.0"
   characters:
     dependency: transitive
     description:
@@ -273,7 +273,7 @@ packages:
       name: firebase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.2"
+    version: "7.3.3"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -369,14 +369,14 @@ packages:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   flutter_colorpicker:
     dependency: "direct main"
     description:
       name: flutter_colorpicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -468,7 +468,7 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.7+14"
+    version: "0.6.7+17"
   image_picker_platform_interface:
     dependency: transitive
     description:
@@ -566,7 +566,7 @@ packages:
       name: network_image_mock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   node_interop:
     dependency: transitive
     description:
@@ -713,7 +713,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2+2"
+    version: "4.3.2+3"
   pub_semver:
     dependency: transitive
     description:
@@ -802,7 +802,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10+1"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -161,6 +161,9 @@ dev_dependencies:
   # Using Provider for state management
   provider: ^4.0.4
 
+dependency_overrides:
+  # Downgrade the version till version of intl_translation will be fixed
+  intl: ^0.17.0-nullsafety.2
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -162,7 +162,7 @@ dev_dependencies:
   provider: ^4.0.4
 
 dependency_overrides:
-  # Downgrade the version till version of intl_translation will be fixed
+  # Temporary workaround to bypass intl_translation incompatibility
   intl: ^0.17.0-nullsafety.2
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -824,9 +824,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect previous week
-          final currentWeek =
-              WeekYearRules.iso.getWeekOfWeekYear(LocalDate.today());
-          expect(find.text((currentWeek - 1).toString()), findsOneWidget);
+          final previousWeek = WeekYearRules.iso
+              .getWeekOfWeekYear(LocalDate.today().subtractWeeks(1));
+          expect(find.text(previousWeek.toString()), findsOneWidget);
 
           expect(find.text('Holiday'), findsNothing);
           expect(find.text('Inter-semester holiday'), findsNothing);
@@ -847,6 +847,8 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect current week
+          final currentWeek =
+              WeekYearRules.iso.getWeekOfWeekYear(LocalDate.today());
           expect(find.text(currentWeek.toString()), findsOneWidget);
 
           expect(find.text('Holiday'), findsNothing);
@@ -868,7 +870,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect next week
-          expect(find.text((currentWeek + 1).toString()), findsOneWidget);
+          final nextWeek = WeekYearRules.iso
+              .getWeekOfWeekYear(LocalDate.today().addWeeks(1));
+          expect(find.text(nextWeek.toString()), findsOneWidget);
 
           expect(find.text('Holiday'), findsOneWidget);
           expect(find.text('Inter-semester holiday'), findsOneWidget);
@@ -889,7 +893,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect next week
-          expect(find.text((currentWeek + 2).toString()), findsOneWidget);
+          final nextNextWeek = WeekYearRules.iso
+              .getWeekOfWeekYear(LocalDate.today().addWeeks(2));
+          expect(find.text(nextNextWeek.toString()), findsOneWidget);
 
           expect(find.text('Holiday'), findsNothing);
           expect(find.text('Inter-semester holiday'), findsOneWidget);
@@ -910,7 +916,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect next week
-          expect(find.text((currentWeek + 3).toString()), findsOneWidget);
+          final nextNextNextWeek = WeekYearRules.iso
+              .getWeekOfWeekYear(LocalDate.today().addWeeks(3));
+          expect(find.text(nextNextNextWeek.toString()), findsOneWidget);
 
           expect(find.text('Holiday'), findsNothing);
           expect(find.text('Inter-semester holiday'), findsNothing);
@@ -959,7 +967,9 @@ void main() {
           await tester.pumpAndSettle();
 
           // Expect next week
-          expect(find.text((currentWeek + 1).toString()), findsOneWidget);
+          final nextWeek = WeekYearRules.iso
+              .getWeekOfWeekYear(LocalDate.today().addWeeks(1));
+          expect(find.text(nextWeek.toString()), findsOneWidget);
 
           // Open holiday event
           await tester.tap(find.text('Holiday'));
@@ -984,8 +994,6 @@ void main() {
           await tester.pumpAndSettle();
 
           // Open add event page
-          // await tester.tapAt(
-          //     tester.getCenter(find.byType(TimetablePage)).translate(0, 100));
           await tester
               .tapAt(tester.getCenter(find.text('Sat')).translate(0, 100));
           await tester.pumpAndSettle();


### PR DESCRIPTION
Running flutter pub get leads to the following error: 
```
Because no versions of intl_translation match >0.17.10+1 <0.18.0 and intl_translation 0.17.10+1 depends on intl >=0.15.3 <0.17.0, intl_translation ^0.17.10+1 requires intl >=0.15.3 <0.17.0.
And because every version of flutter_localizations from sdk depends on intl 0.17.0-nullsafety.2, intl_translation ^0.17.10+1 is incompatible with flutter_localizations from sdk.
So, because acs_upb_mobile depends on both flutter_localizations any from sdk and intl_translation ^0.17.10+1, version solving failed.
pub get failed (1; So, because acs_upb_mobile depends on both flutter_localizations any from sdk and intl_translation ^0.17.10+1, version solving failed.)
```
 This is caused by the incompatibility between the `flutter_localizations` package and `intl_translation` package.
 The temporary solution is to downgrade the `intl` package by overriding the dependency.