### PR TITLE
Migrate to the new firebase_core

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,7 @@ analyzer:
   exclude:
     - build/**
     - lib/generated/**
+    - test/firebase_mock.dart
 
 linter:
   rules:

--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -245,12 +245,10 @@ class AuthProvider with ChangeNotifier {
   }
 
   Future<void> signOut() async {
-    if (isAnonymous) {
-      await FirebaseAuth.instance.signOut();
+    if (isAuthenticated && isAnonymous) {
       await delete();
-    } else {
-      await FirebaseAuth.instance.signOut();
     }
+    await FirebaseAuth.instance.signOut();
   }
 
   Future<bool> delete({BuildContext context}) async {

--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -358,10 +358,6 @@ class AuthProvider with ChangeNotifier {
       final UserCredential credential = await FirebaseAuth.instance
           .createUserWithEmailAndPassword(email: email, password: password);
 
-      // Update display name
-      await credential.user.updateProfile(displayName: '$firstName $lastName');
-      await credential.user.reload();
-
       // Create document in 'users'
       _currentUser = User(
         uid: credential.user.uid,
@@ -429,10 +425,6 @@ class AuthProvider with ChangeNotifier {
           .collection('users')
           .doc(_currentUser.uid)
           .update(_currentUser.toData());
-
-      // Update display name
-      await _firebaseUser.updateProfile(displayName: '$firstName $lastName');
-      await _firebaseUser.reload();
 
       notifyListeners();
       return true;

--- a/lib/authentication/service/auth_provider.dart
+++ b/lib/authentication/service/auth_provider.dart
@@ -7,17 +7,19 @@ import 'package:acs_upb_mobile/resources/storage/storage_provider.dart';
 import 'package:acs_upb_mobile/resources/validator.dart';
 import 'package:acs_upb_mobile/widgets/toast.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' hide User;
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth show User;
 import 'package:flutter/material.dart';
 
 extension DatabaseUser on User {
   static User fromSnap(DocumentSnapshot snap) {
+    final data = snap.data();
     return User(
-        uid: snap.documentID,
-        firstName: snap.data['name']['first'],
-        lastName: snap.data['name']['last'],
-        classes: List.from(snap.data['class'] ?? []),
-        permissionLevel: snap.data['permissionLevel']);
+        uid: snap.id,
+        firstName: data['name']['first'],
+        lastName: data['name']['last'],
+        classes: List.from(data['class'] ?? []),
+        permissionLevel: data['permissionLevel']);
   }
 
   Map<String, dynamic> toData() {
@@ -31,19 +33,18 @@ extension DatabaseUser on User {
 
 class AuthProvider with ChangeNotifier {
   AuthProvider() {
-    _userAuthSub = FirebaseAuth.instance.onAuthStateChanged.listen((newUser) {
-      print('AuthProvider - FirebaseAuth - onAuthStateChanged - $newUser');
-      _firebaseUser = newUser;
+    _userAuthSub = FirebaseAuth.instance.authStateChanges().listen((newUser) {
+      print('AuthProvider - FirebaseAuth - authStateChanges - $newUser');
       _currentUser = null;
       _fetchUser();
       notifyListeners();
     }, onError: (dynamic e) {
-      print('AuthProvider - FirebaseAuth - onAuthStateChanged - $e');
+      print('AuthProvider - FirebaseAuth - authStateChanges - $e');
     });
   }
 
-  FirebaseUser _firebaseUser;
-  StreamSubscription<FirebaseUser> _userAuthSub;
+  firebase_auth.User get _firebaseUser => FirebaseAuth.instance.currentUser;
+  StreamSubscription<firebase_auth.User> _userAuthSub;
   User _currentUser;
 
   @override
@@ -98,9 +99,7 @@ class AuthProvider with ChangeNotifier {
 
     var isAnonymousUser = true;
     for (final info in _firebaseUser.providerData) {
-      if (info.providerId == 'facebook.com' ||
-          info.providerId == 'google.com' ||
-          info.providerId == 'password') {
+      if (info.providerId == 'password') {
         isAnonymousUser = false;
         break;
       }
@@ -108,35 +107,15 @@ class AuthProvider with ChangeNotifier {
     return isAnonymousUser;
   }
 
-  /// Check the memory cache to see if there is a user authenticated
-  bool get isVerifiedFromCache {
+  /// Check if the user verified their e-mail
+  Future<bool> get isVerified async {
     assert(_firebaseUser != null);
-    return !isAnonymous && _firebaseUser.isEmailVerified;
-  }
-
-  /// Check the network to see if there is a user authenticated
-  Future<bool> get isVerifiedFromService async {
-    if (isAnonymous) {
-      return false;
-    }
-
     await _firebaseUser.reload();
-    _firebaseUser = await FirebaseAuth.instance.currentUser();
-    return _firebaseUser.isEmailVerified;
+    return !isAnonymous && _firebaseUser.emailVerified;
   }
 
-  /// Check the memory cache to see if there is a user authenticated
-  bool get isAuthenticatedFromCache {
-    return _firebaseUser != null;
-  }
-
-  /// Check the filesystem to see if there is a user authenticated.
-  ///
-  /// This method is `async` and should only be necessary on app startup, since
-  /// for everything else, the [AuthProvider] will notify its listeners and
-  /// update the cache if the authentication state changes.
-  Future<bool> get isAuthenticatedFromService async {
-    _firebaseUser = await FirebaseAuth.instance.currentUser();
+  /// Check if there is a user authenticated
+  bool get isAuthenticated {
     return _firebaseUser != null;
   }
 
@@ -146,7 +125,7 @@ class AuthProvider with ChangeNotifier {
 
   String get email => _firebaseUser.email;
 
-  bool isOldFormat(Map<String, dynamic> userData) =>
+  bool _isOldFormat(Map<String, dynamic> userData) =>
       userData['class'] != null && userData['class'] is Map;
 
   /// Change the `class` of the user data in Firebase to the new format.
@@ -155,7 +134,7 @@ class AuthProvider with ChangeNotifier {
   /// where the key is the name of the level in the filter tree.
   /// In the new format, the class is simply a `List<String>` that contains the
   /// name of the nodes.
-  Future<void> migrateToNewClassFormat(Map<String, dynamic> userData) async {
+  Future<void> _migrateToNewClassFormat(Map<String, dynamic> userData) async {
     final classes = ['degree', 'domain', 'year', 'series', 'group', 'subgroup']
         .map((key) => userData['class'][key].toString())
         .where((s) => s != 'null')
@@ -163,24 +142,25 @@ class AuthProvider with ChangeNotifier {
 
     userData['class'] = classes;
 
-    await Firestore.instance
+    await FirebaseFirestore.instance
         .collection('users')
-        .document(_firebaseUser.uid)
-        .updateData(userData);
+        .doc(_firebaseUser.uid)
+        .update(userData);
   }
 
   Future<User> _fetchUser() async {
     if (isAnonymous) {
       return null;
     }
-    final snapshot = await Firestore.instance
+    final snapshot = await FirebaseFirestore.instance
         .collection('users')
-        .document(_firebaseUser.uid)
+        .doc(_firebaseUser.uid)
         .get();
-    if (snapshot.data == null) return null;
+    final data = snapshot.data();
+    if (data == null) return null;
 
-    if (isOldFormat(snapshot.data)) {
-      await migrateToNewClassFormat(snapshot.data);
+    if (_isOldFormat(data)) {
+      await _migrateToNewClassFormat(data);
     }
 
     _currentUser = DatabaseUser.fromSnap(snapshot);
@@ -237,7 +217,7 @@ class AuthProvider with ChangeNotifier {
     }
 
     final List<String> providers = await FirebaseAuth.instance
-        .fetchSignInMethodsForEmail(email: email)
+        .fetchSignInMethodsForEmail(email)
         .catchError((dynamic e) {
       _errorHandler(e, context);
       return null;
@@ -265,19 +245,20 @@ class AuthProvider with ChangeNotifier {
   }
 
   Future<void> signOut() async {
-    await FirebaseAuth.instance.signOut();
     if (isAnonymous) {
+      await FirebaseAuth.instance.signOut();
       await delete();
+    } else {
+      await FirebaseAuth.instance.signOut();
     }
   }
 
   Future<bool> delete({BuildContext context}) async {
-    _firebaseUser ??= await FirebaseAuth.instance.currentUser();
     assert(_firebaseUser != null);
 
     try {
       final DocumentReference ref =
-          Firestore.instance.collection('users').document(_firebaseUser.uid);
+          FirebaseFirestore.instance.collection('users').doc(_firebaseUser.uid);
       await ref.delete();
 
       await _firebaseUser.delete();
@@ -296,8 +277,7 @@ class AuthProvider with ChangeNotifier {
       {String email, BuildContext context}) async {
     List<String> providers = [];
     try {
-      providers =
-          await FirebaseAuth.instance.fetchSignInMethodsForEmail(email: email);
+      providers = await FirebaseAuth.instance.fetchSignInMethodsForEmail(email);
     } catch (e) {
       _errorHandler(e, context);
       return false;
@@ -312,8 +292,7 @@ class AuthProvider with ChangeNotifier {
   Future<bool> canSignUpWithEmail({String email, BuildContext context}) async {
     List<String> providers = [];
     try {
-      providers =
-          await FirebaseAuth.instance.fetchSignInMethodsForEmail(email: email);
+      providers = await FirebaseAuth.instance.fetchSignInMethodsForEmail(email);
     } catch (e) {
       _errorHandler(e, context);
       return false;
@@ -378,33 +357,28 @@ class AuthProvider with ChangeNotifier {
       }
 
       // Create user
-      final AuthResult res = await FirebaseAuth.instance
+      final UserCredential credential = await FirebaseAuth.instance
           .createUserWithEmailAndPassword(email: email, password: password);
 
       // Update display name
-      final userUpdateInfo = UserUpdateInfo()
-        ..displayName = '$firstName $lastName';
-      await res.user.updateProfile(userUpdateInfo);
-
-      // Update user with updated info
-      await _firebaseUser?.reload();
-      _firebaseUser = await FirebaseAuth.instance.currentUser();
+      await credential.user.updateProfile(displayName: '$firstName $lastName');
+      await credential.user.reload();
 
       // Create document in 'users'
       _currentUser = User(
-        uid: res.user.uid,
+        uid: credential.user.uid,
         firstName: firstName,
         lastName: lastName,
         classes: classes,
       );
 
       final DocumentReference ref =
-          Firestore.instance.collection('users').document(_currentUser.uid);
-      await ref.setData(_currentUser.toData());
+          FirebaseFirestore.instance.collection('users').doc(_currentUser.uid);
+      await ref.set(_currentUser.toData());
 
       // Try to set the default from the user data
       if (_currentUser.classes != null) {
-        await ref.updateData({'filter_nodes': _currentUser.classes});
+        await ref.update({'filter_nodes': _currentUser.classes});
       }
       // Send verification e-mail
       await _firebaseUser.sendEmailVerification();
@@ -453,15 +427,14 @@ class AuthProvider with ChangeNotifier {
         ..lastName = lastName
         ..classes = classes;
 
-      await Firestore.instance
+      await FirebaseFirestore.instance
           .collection('users')
-          .document(_currentUser.uid)
-          .updateData(_currentUser.toData());
+          .doc(_currentUser.uid)
+          .update(_currentUser.toData());
 
       // Update display name
-      final userUpdateInfo = UserUpdateInfo()
-        ..displayName = '$firstName $lastName';
-      await _firebaseUser.updateProfile(userUpdateInfo);
+      await _firebaseUser.updateProfile(displayName: '$firstName $lastName');
+      await _firebaseUser.reload();
 
       notifyListeners();
       return true;

--- a/lib/authentication/view/edit_profile_page.dart
+++ b/lib/authentication/view/edit_profile_page.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 
 import 'package:acs_upb_mobile/authentication/model/user.dart';
 import 'package:acs_upb_mobile/authentication/service/auth_provider.dart';
-
 import 'package:acs_upb_mobile/generated/l10n.dart';
 import 'package:acs_upb_mobile/pages/filter/view/filter_dropdown.dart';
 import 'package:acs_upb_mobile/resources/storage/storage_provider.dart';
@@ -18,9 +17,9 @@ import 'package:acs_upb_mobile/widgets/toast.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:image/image.dart' as im;
 import 'package:preferences/preference_title.dart';
 import 'package:provider/provider.dart';
-import 'package:image/image.dart' as im;
 
 class EditProfilePage extends StatefulWidget {
   const EditProfilePage({Key key}) : super(key: key);
@@ -417,8 +416,7 @@ class AccountNotVerifiedWarning extends StatelessWidget {
   Widget build(BuildContext context) {
     final authProvider = Provider.of<AuthProvider>(context);
 
-    if (!authProvider.isAuthenticated ||
-        authProvider.isAnonymous) {
+    if (!authProvider.isAuthenticated || authProvider.isAnonymous) {
       return Container();
     }
 

--- a/lib/authentication/view/sign_up_view.dart
+++ b/lib/authentication/view/sign_up_view.dart
@@ -63,7 +63,7 @@ class _SignUpViewState extends State<SignUpView> {
       return formItems;
     }
     final emailDomain = S.of(context).stringEmailDomain;
-    final authProvider = Provider.of<AuthProvider>(context);
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
 
     return formItems = <FormCardField>[
       FormCardField(
@@ -155,7 +155,7 @@ class _SignUpViewState extends State<SignUpView> {
   }
 
   FormCard _buildForm(BuildContext context) {
-    final authProvider = Provider.of<AuthProvider>(context);
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
 
     return FormCard(
       title: S.of(context).actionSignUp,

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1,6 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+
 import 'intl/messages_all.dart';
 
 // **************************************************************************
@@ -14,22 +15,23 @@ import 'intl/messages_all.dart';
 
 class S {
   S();
-  
+
   static S current;
-  
-  static const AppLocalizationDelegate delegate =
-    AppLocalizationDelegate();
+
+  static const AppLocalizationDelegate delegate = AppLocalizationDelegate();
 
   static Future<S> load(Locale locale) {
-    final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
-    final localeName = Intl.canonicalizedLocale(name); 
+    final name = (locale.countryCode?.isEmpty ?? false)
+        ? locale.languageCode
+        : locale.toString();
+    final localeName = Intl.canonicalizedLocale(name);
     return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       S.current = S();
-      
+
       return S.current;
     });
-  } 
+  }
 
   static S of(BuildContext context) {
     return Localizations.of<S>(context, S);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:acs_upb_mobile/resources/utils.dart';
 import 'package:acs_upb_mobile/widgets/loading_screen.dart';
 import 'package:dynamic_theme/dynamic_theme.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -34,6 +35,8 @@ import 'package:time_machine/time_machine.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  await Firebase.initializeApp();
 
   final authProvider = AuthProvider();
   final classProvider = ClassProvider();
@@ -173,8 +176,7 @@ class AppLoadingScreen extends StatelessWidget {
 
     // Choose start screen
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
-    final bool authenticated = await authProvider.isAuthenticatedFromService;
-    return authenticated ? Routes.home : Routes.login;
+    return authProvider.isAuthenticated ? Routes.home : Routes.login;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:acs_upb_mobile/pages/news_feed/view/news_feed_page.dart';
 import 'package:acs_upb_mobile/pages/people/service/person_provider.dart';
 import 'package:acs_upb_mobile/pages/portal/service/website_provider.dart';
 import 'package:acs_upb_mobile/pages/settings/service/request_provider.dart';
+import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
 import 'package:acs_upb_mobile/pages/settings/view/settings_page.dart';
 import 'package:acs_upb_mobile/pages/timetable/service/uni_event_provider.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
@@ -101,6 +102,7 @@ class _MyAppState extends State<MyApp> {
         Routes.faq: (_) => FaqPage(),
         Routes.filter: (_) => const FilterPage(),
         Routes.newsFeed: (_) => NewsFeedPage(),
+        Routes.requestPermissions: (_) => RequestPermissionsPage(),
       },
       navigatorObservers: widget.navigationObservers ?? [],
     );

--- a/lib/navigation/routes.dart
+++ b/lib/navigation/routes.dart
@@ -3,6 +3,7 @@ import 'package:acs_upb_mobile/authentication/view/sign_up_view.dart';
 import 'package:acs_upb_mobile/pages/faq/view/faq_page.dart';
 import 'package:acs_upb_mobile/pages/filter/view/filter_page.dart';
 import 'package:acs_upb_mobile/pages/news_feed/view/news_feed_page.dart';
+import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
 import 'package:acs_upb_mobile/pages/settings/view/settings_page.dart';
 
 class Routes {
@@ -16,4 +17,5 @@ class Routes {
   static const String signUp = SignUpView.routeName;
   static const String faq = FaqPage.routeName;
   static const String newsFeed = NewsFeedPage.routeName;
+  static const String requestPermissions = RequestPermissionsPage.routeName;
 }

--- a/lib/pages/faq/service/question_provider.dart
+++ b/lib/pages/faq/service/question_provider.dart
@@ -9,12 +9,12 @@ class QuestionProvider with ChangeNotifier {
       {BuildContext context, int limit}) async {
     try {
       final QuerySnapshot qSnapshot = limit == null
-          ? await Firestore.instance.collection('faq').getDocuments()
-          : await Firestore.instance
+          ? await FirebaseFirestore.instance.collection('faq').get()
+          : await FirebaseFirestore.instance
               .collection('faq')
               .limit(limit)
-              .getDocuments();
-      return qSnapshot.documents.map(DatabaseQuestion.fromSnap).toList();
+              .get();
+      return qSnapshot.docs.map(DatabaseQuestion.fromSnap).toList();
     } catch (e) {
       print(e);
       if (context != null) {
@@ -27,9 +27,12 @@ class QuestionProvider with ChangeNotifier {
 
 extension DatabaseQuestion on Question {
   static Question fromSnap(DocumentSnapshot snap) {
-    final String question = snap.data['question'];
-    final String answer = snap.data['answer'];
-    final List<String> tags = List.from(snap.data['tags']);
+    final data = snap.data();
+
+    final String question = data['question'];
+    final String answer = data['answer'];
+    final List<String> tags = List.from(data['tags']);
+
     return Question(question: question, answer: answer, tags: tags);
   }
 }

--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -35,7 +35,7 @@ class FilterProvider with ChangeNotifier {
     }
   }
 
-  final Firestore _db = Firestore.instance;
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
   Filter _relevanceFilter; // filter cache
 
   /// Whether this is the global filter instance and should update shared preferences
@@ -69,8 +69,8 @@ class FilterProvider with ChangeNotifier {
   Future<void> _setFilterNodes(List<String> nodes) async {
     try {
       final DocumentReference doc =
-          _db.collection('users').document(_authProvider.uid);
-      await doc.updateData({'filter_nodes': nodes});
+          _db.collection('users').doc(_authProvider.uid);
+      await doc.update({'filter_nodes': nodes});
     } catch (e) {
       print(e);
     }
@@ -115,9 +115,9 @@ class FilterProvider with ChangeNotifier {
 
     try {
       final col = _db.collection('filters');
-      final ref = col.document('relevance');
+      final ref = col.doc('relevance');
       final doc = await ref.get();
-      final data = doc.data;
+      final data = doc.data();
 
       final levelNames = <Map<String, String>>[];
       // Cast from List<dynamic> to List<Map<String, String>>
@@ -142,10 +142,10 @@ class FilterProvider with ChangeNotifier {
 
       // Check if there is an existing setting already
       if (global &&
-          _authProvider.isAuthenticatedFromCache &&
+          _authProvider.isAuthenticated &&
           !_authProvider.isAnonymous) {
         final DocumentReference docUsers =
-            _db.collection('users').document(_authProvider.uid);
+            _db.collection('users').doc(_authProvider.uid);
         final DocumentSnapshot snapUsers = await docUsers.get();
 
         //Load filter_nodes from Firestore

--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -144,13 +144,12 @@ class FilterProvider with ChangeNotifier {
       if (global &&
           _authProvider.isAuthenticated &&
           !_authProvider.isAnonymous) {
-        final DocumentReference docUsers =
-            _db.collection('users').doc(_authProvider.uid);
-        final DocumentSnapshot snapUsers = await docUsers.get();
+        final userSnap =
+            await _db.collection('users').doc(_authProvider.uid).get();
 
         //Load filter_nodes from Firestore
-        _relevantNodes = List<String>.from(snapUsers['filter_nodes']);
-        _relevanceFilter.setRelevantNodes(_relevantNodes);
+        _relevantNodes = List<String>.from(userSnap['filter_nodes']);
+        _relevanceFilter?.setRelevantNodes(_relevantNodes);
       }
 
       return cachedFilter;

--- a/lib/pages/filter/view/filter_dropdown.dart
+++ b/lib/pages/filter/view/filter_dropdown.dart
@@ -98,7 +98,10 @@ class _FilterDropdownState extends State<FilterDropdown> {
             children: _buildDropdowns(context),
           );
         }
-        return const Center(child: CircularProgressIndicator());
+        return const Padding(
+          padding: EdgeInsets.only(top: 16),
+          child: Center(child: CircularProgressIndicator()),
+        );
       },
     );
   }

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:acs_upb_mobile/authentication/service/auth_provider.dart';
 import 'package:acs_upb_mobile/generated/l10n.dart';
 import 'package:acs_upb_mobile/navigation/routes.dart';
 import 'package:acs_upb_mobile/pages/home/faq_card.dart';
@@ -7,6 +8,7 @@ import 'package:acs_upb_mobile/pages/home/profile_card.dart';
 import 'package:acs_upb_mobile/widgets/scaffold.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({this.tabController, Key key}) : super(key: key);
@@ -15,6 +17,8 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final authProvider = Provider.of<AuthProvider>(context);
+
     return AppScaffold(
       title: Text(S.of(context).navigationHome),
       actions: [
@@ -26,8 +30,10 @@ class HomePage extends StatelessWidget {
       ],
       body: ListView(
         children: [
-          ProfileCard(),
-          FavouriteWebsitesCard(onShowMore: () => tabController?.animateTo(2)),
+          if (authProvider.isAuthenticated) ProfileCard(),
+          if (authProvider.isAuthenticated)
+            FavouriteWebsitesCard(
+                onShowMore: () => tabController?.animateTo(2)),
           NewsFeedCard(),
           FaqCard(),
         ],

--- a/lib/pages/people/service/person_provider.dart
+++ b/lib/pages/people/service/person_provider.dart
@@ -7,13 +7,14 @@ import 'package:flutter/material.dart';
 
 extension PersonExtension on Person {
   static Person fromSnap(DocumentSnapshot snap) {
+    final data = snap.data();
     return Person(
-      name: snap.data['name'],
-      email: snap.data['email'],
-      phone: snap.data['phone'],
-      office: snap.data['office'],
-      position: snap.data['position'],
-      photo: snap.data['photo'],
+      name: data['name'],
+      email: data['email'],
+      phone: data['phone'],
+      office: data['office'],
+      position: data['position'],
+      photo: data['photo'],
     );
   }
 }
@@ -22,8 +23,8 @@ class PersonProvider with ChangeNotifier {
   Future<List<Person>> fetchPeople({BuildContext context}) async {
     try {
       final QuerySnapshot qSnapshot =
-          await Firestore.instance.collection('people').getDocuments();
-      return qSnapshot.documents.map(PersonExtension.fromSnap).toList();
+          await FirebaseFirestore.instance.collection('people').get();
+      return qSnapshot.docs.map(PersonExtension.fromSnap).toList();
     } catch (e) {
       print(e);
       if (context != null) {

--- a/lib/pages/portal/service/website_provider.dart
+++ b/lib/pages/portal/service/website_provider.dart
@@ -114,15 +114,20 @@ class WebsiteProvider with ChangeNotifier {
       return _initializeNumberOfVisitsLocally(websites);
     }
     try {
-      final DocumentReference doc = _db.collection('users').doc(uid);
-      final DocumentSnapshot snap = await doc.get();
+      final DocumentReference userDoc = _db.collection('users').doc(uid);
+      final userData = (await userDoc.get()).data();
 
-      final websiteVisits =
-          Map<String, dynamic>.from(snap.data()['websiteVisits'] ?? {});
-      for (final website in websites) {
-        website.numberOfVisits = websiteVisits[website.id] ?? 0;
+      if (userData != null) {
+        final websiteVisits =
+            Map<String, dynamic>.from(userData['websiteVisits'] ?? {});
+        for (final website in websites) {
+          website.numberOfVisits = websiteVisits[website.id] ?? 0;
+        }
+        return true;
+      } else {
+        print('User not found.');
+        return false;
       }
-      return true;
     } catch (e) {
       print(e);
       return false;
@@ -163,15 +168,22 @@ class WebsiteProvider with ChangeNotifier {
       if (uid == null) {
         return await incrementNumberOfVisitsLocally(website);
       }
-      final DocumentReference doc = _db.collection('users').doc(uid);
-      final DocumentSnapshot snap = await doc.get();
-      final websiteVisits =
-          Map<String, dynamic>.from(snap.data()['websiteVisits'] ?? {});
-      websiteVisits[website.id] = website.numberOfVisits++;
 
-      await doc.update({'websiteVisits': websiteVisits});
-      notifyListeners();
-      return true;
+      final DocumentReference userDoc = _db.collection('users').doc(uid);
+      final userData = (await userDoc.get()).data();
+
+      if (userData != null) {
+        final websiteVisits =
+            Map<String, dynamic>.from(userData['websiteVisits'] ?? {});
+        websiteVisits[website.id] = website.numberOfVisits++;
+
+        await userDoc.update({'websiteVisits': websiteVisits});
+        notifyListeners();
+        return true;
+      } else {
+        print('User not found.');
+        return false;
+      }
     } catch (e) {
       print(e);
       return false;

--- a/lib/pages/portal/service/website_provider.dart
+++ b/lib/pages/portal/service/website_provider.dart
@@ -320,7 +320,7 @@ class WebsiteProvider with ChangeNotifier {
             .doc(website.id);
       }
 
-      if ((await ref.get()).data != null) {
+      if ((await ref.get()).data() != null) {
         // TODO(IoanaAlexandru): Properly check if a website with a similar name/link already exists
         print('A website with id ${website.id} already exists');
         if (context != null) {
@@ -354,10 +354,10 @@ class WebsiteProvider with ChangeNotifier {
 
       DocumentReference previousRef;
       bool wasPrivate;
-      if ((await publicRef.get()).data != null) {
+      if ((await publicRef.get()).data() != null) {
         wasPrivate = false;
         previousRef = publicRef;
-      } else if ((await privateRef.get()).data != null) {
+      } else if ((await privateRef.get()).data() != null) {
         wasPrivate = true;
         previousRef = privateRef;
       } else {

--- a/lib/pages/portal/service/website_provider.dart
+++ b/lib/pages/portal/service/website_provider.dart
@@ -21,11 +21,11 @@ extension UserExtension on User {
 
   /// Check if user has at least one private website
   Future<bool> get hasPrivateWebsites async {
-    final CollectionReference ref = Firestore.instance
+    final CollectionReference ref = FirebaseFirestore.instance
         .collection('users')
-        .document(uid)
+        .doc(uid)
         .collection('websites');
-    return (await ref.getDocuments()).documents.isNotEmpty;
+    return (await ref.get()).docs.isNotEmpty;
   }
 }
 
@@ -49,24 +49,25 @@ extension WebsiteCategoryExtension on WebsiteCategory {
 extension WebsiteExtension on Website {
   // [ownerUid] should be provided if the website is user-private
   static Website fromSnap(DocumentSnapshot snap, {String ownerUid}) {
+    final data = snap.data();
     return Website(
-      ownerUid: ownerUid ?? snap.data['addedBy'],
-      id: snap.documentID,
+      ownerUid: ownerUid ?? data['addedBy'],
+      id: snap.id,
       isPrivate: ownerUid != null,
-      editedBy: List<String>.from(snap.data['editedBy'] ?? []),
-      category: WebsiteCategoryExtension.fromString(snap.data['category']),
-      label: snap.data['label'] ?? 'Website',
-      link: snap.data['link'] ?? '',
-      infoByLocale: snap.data['info'] == null
+      editedBy: List<String>.from(data['editedBy'] ?? []),
+      category: WebsiteCategoryExtension.fromString(data['category']),
+      label: data['label'] ?? 'Website',
+      link: data['link'] ?? '',
+      infoByLocale: data['info'] == null
           ? {}
           : {
-              'en': snap.data['info']['en'],
-              'ro': snap.data['info']['ro'],
+              'en': data['info']['en'],
+              'ro': data['info']['ro'],
             },
-      degree: snap.data['degree'],
-      relevance: snap.data['relevance'] == null
+      degree: data['degree'],
+      relevance: data['relevance'] == null
           ? null
-          : List<String>.from(snap.data['relevance']),
+          : List<String>.from(data['relevance']),
     );
   }
 
@@ -92,7 +93,7 @@ extension WebsiteExtension on Website {
 }
 
 class WebsiteProvider with ChangeNotifier {
-  final Firestore _db = Firestore.instance;
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
 
   void _errorHandler(dynamic e, BuildContext context) {
     print(e.message);
@@ -113,11 +114,11 @@ class WebsiteProvider with ChangeNotifier {
       return _initializeNumberOfVisitsLocally(websites);
     }
     try {
-      final DocumentReference doc = _db.collection('users').document(uid);
+      final DocumentReference doc = _db.collection('users').doc(uid);
       final DocumentSnapshot snap = await doc.get();
 
       final websiteVisits =
-          Map<String, dynamic>.from(snap.data['websiteVisits'] ?? {});
+          Map<String, dynamic>.from(snap.data()['websiteVisits'] ?? {});
       for (final website in websites) {
         website.numberOfVisits = websiteVisits[website.id] ?? 0;
       }
@@ -162,13 +163,13 @@ class WebsiteProvider with ChangeNotifier {
       if (uid == null) {
         return await incrementNumberOfVisitsLocally(website);
       }
-      final DocumentReference doc = _db.collection('users').document(uid);
+      final DocumentReference doc = _db.collection('users').doc(uid);
       final DocumentSnapshot snap = await doc.get();
       final websiteVisits =
-          Map<String, dynamic>.from(snap.data['websiteVisits'] ?? {});
+          Map<String, dynamic>.from(snap.data()['websiteVisits'] ?? {});
       websiteVisits[website.id] = website.numberOfVisits++;
 
-      await doc.updateData({'websiteVisits': websiteVisits});
+      await doc.update({'websiteVisits': websiteVisits});
       notifyListeners();
       return true;
     } catch (e) {
@@ -220,14 +221,14 @@ class WebsiteProvider with ChangeNotifier {
 
         if (filter == null) {
           final QuerySnapshot qSnapshot =
-              await _db.collection('websites').getDocuments();
-          documents.addAll(qSnapshot.documents);
+              await _db.collection('websites').get();
+          documents.addAll(qSnapshot.docs);
         } else {
           // Documents without a 'relevance' field are relevant for everyone
           final query =
               _db.collection('websites').where('relevance', isNull: true);
-          final QuerySnapshot qSnapshot = await query.getDocuments();
-          documents.addAll(qSnapshot.documents);
+          final QuerySnapshot qSnapshot = await query.get();
+          documents.addAll(qSnapshot.docs);
 
           for (final string in filter.relevantNodes) {
             // selected nodes
@@ -235,8 +236,8 @@ class WebsiteProvider with ChangeNotifier {
                 .collection('websites')
                 .where('degree', isEqualTo: filter.baseNode)
                 .where('relevance', arrayContains: string);
-            final QuerySnapshot qSnapshot = await query.getDocuments();
-            documents.addAll(qSnapshot.documents);
+            final QuerySnapshot qSnapshot = await query.get();
+            documents.addAll(qSnapshot.docs);
           }
         }
 
@@ -244,9 +245,8 @@ class WebsiteProvider with ChangeNotifier {
         // (a document may result out of more than one query)
         final seenDocumentIds = <String>{};
 
-        documents = documents
-            .where((doc) => seenDocumentIds.add(doc.documentID))
-            .toList();
+        documents =
+            documents.where((doc) => seenDocumentIds.add(doc.id)).toList();
 
         websites.addAll(documents.map(WebsiteExtension.fromSnap));
       }
@@ -254,11 +254,10 @@ class WebsiteProvider with ChangeNotifier {
       // Get user-added websites
       if (uid != null) {
         final DocumentReference ref =
-            Firestore.instance.collection('users').document(uid);
-        final QuerySnapshot qSnapshot =
-            await ref.collection('websites').getDocuments();
+            FirebaseFirestore.instance.collection('users').doc(uid);
+        final QuerySnapshot qSnapshot = await ref.collection('websites').get();
 
-        websites.addAll(qSnapshot.documents
+        websites.addAll(qSnapshot.docs
             .map((doc) => WebsiteExtension.fromSnap(doc, ownerUid: uid)));
       }
 
@@ -300,13 +299,13 @@ class WebsiteProvider with ChangeNotifier {
     try {
       DocumentReference ref;
       if (!website.isPrivate) {
-        ref = _db.collection('websites').document(website.id);
+        ref = _db.collection('websites').doc(website.id);
       } else {
         ref = _db
             .collection('users')
-            .document(website.ownerUid)
+            .doc(website.ownerUid)
             .collection('websites')
-            .document(website.id);
+            .doc(website.id);
       }
 
       if ((await ref.get()).data != null) {
@@ -319,7 +318,7 @@ class WebsiteProvider with ChangeNotifier {
       }
 
       final data = website.toData();
-      await ref.setData(data);
+      await ref.set(data);
 
       notifyListeners();
       return true;
@@ -334,12 +333,12 @@ class WebsiteProvider with ChangeNotifier {
 
     try {
       final DocumentReference publicRef =
-          _db.collection('websites').document(website.id);
+          _db.collection('websites').doc(website.id);
       final DocumentReference privateRef = _db
           .collection('users')
-          .document(website.ownerUid)
+          .doc(website.ownerUid)
           .collection('websites')
-          .document(website.id);
+          .doc(website.id);
 
       DocumentReference previousRef;
       bool wasPrivate;
@@ -356,11 +355,11 @@ class WebsiteProvider with ChangeNotifier {
 
       if (wasPrivate == website.isPrivate) {
         // No privacy change
-        await previousRef.updateData(website.toData());
+        await previousRef.update(website.toData());
       } else {
         // Privacy changed
         await previousRef.delete();
-        await (wasPrivate ? publicRef : privateRef).setData(website.toData());
+        await (wasPrivate ? publicRef : privateRef).set(website.toData());
       }
 
       notifyListeners();
@@ -375,13 +374,13 @@ class WebsiteProvider with ChangeNotifier {
     try {
       DocumentReference ref;
       if (!website.isPrivate) {
-        ref = _db.collection('websites').document(website.id);
+        ref = _db.collection('websites').doc(website.id);
       } else {
         ref = _db
             .collection('users')
-            .document(website.ownerUid)
+            .doc(website.ownerUid)
             .collection('websites')
-            .document(website.id);
+            .doc(website.id);
       }
 
       await ref.delete();

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -224,7 +224,7 @@ class _PortalPageState extends State<PortalPage> {
           onPressed: () {
             final authProvider =
                 Provider.of<AuthProvider>(context, listen: false);
-            if (authProvider.isAuthenticatedFromCache &&
+            if (authProvider.isAuthenticated &&
                 !authProvider.isAnonymous) {
               // Show message if there is nothing the user can edit
               if (!editingEnabled) {
@@ -258,7 +258,7 @@ class _PortalPageState extends State<PortalPage> {
               );
             },
             S.of(context).filterMenuShowMine: () {
-              if (authProvider.isAuthenticatedFromCache &&
+              if (authProvider.isAuthenticated &&
                   !authProvider.isAnonymous) {
                 // Show message if user has no private websites
                 if (!userOnly) {
@@ -343,7 +343,7 @@ class _AddWebsiteButton extends StatelessWidget {
           onTap: () {
             final authProvider =
                 Provider.of<AuthProvider>(context, listen: false);
-            if (authProvider.isAuthenticatedFromCache &&
+            if (authProvider.isAuthenticated &&
                 !authProvider.isAnonymous) {
               Navigator.of(context)
                   .push(MaterialPageRoute<ChangeNotifierProvider>(

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -224,8 +224,7 @@ class _PortalPageState extends State<PortalPage> {
           onPressed: () {
             final authProvider =
                 Provider.of<AuthProvider>(context, listen: false);
-            if (authProvider.isAuthenticated &&
-                !authProvider.isAnonymous) {
+            if (authProvider.isAuthenticated && !authProvider.isAnonymous) {
               // Show message if there is nothing the user can edit
               if (!editingEnabled) {
                 user.hasEditableWebsites.then((canEdit) {
@@ -258,8 +257,7 @@ class _PortalPageState extends State<PortalPage> {
               );
             },
             S.of(context).filterMenuShowMine: () {
-              if (authProvider.isAuthenticated &&
-                  !authProvider.isAnonymous) {
+              if (authProvider.isAuthenticated && !authProvider.isAnonymous) {
                 // Show message if user has no private websites
                 if (!userOnly) {
                   user.hasPrivateWebsites.then((hasPrivate) {
@@ -343,8 +341,7 @@ class _AddWebsiteButton extends StatelessWidget {
           onTap: () {
             final authProvider =
                 Provider.of<AuthProvider>(context, listen: false);
-            if (authProvider.isAuthenticated &&
-                !authProvider.isAnonymous) {
+            if (authProvider.isAuthenticated && !authProvider.isAnonymous) {
               Navigator.of(context)
                   .push(MaterialPageRoute<ChangeNotifierProvider>(
                 builder: (_) => ChangeNotifierProvider<FilterProvider>(

--- a/lib/pages/settings/service/request_provider.dart
+++ b/lib/pages/settings/service/request_provider.dart
@@ -22,7 +22,7 @@ extension RequestExtension on Request {
 }
 
 class RequestProvider {
-  final Firestore _db = Firestore.instance;
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
   bool userAlreadyRequestedCache;
 
   Future<bool> makeRequest(Request request, {BuildContext context}) async {
@@ -51,7 +51,7 @@ class RequestProvider {
 
     try {
       final DocumentSnapshot snap =
-          await _db.collection('forms').document(userId).get();
+          await _db.collection('forms').doc(userId).get();
       if (snap != null) {
         return userAlreadyRequestedCache = true;
       }

--- a/lib/pages/settings/view/settings_page.dart
+++ b/lib/pages/settings/view/settings_page.dart
@@ -19,10 +19,22 @@ class SettingsPage extends StatefulWidget {
   static const String routeName = '/settings';
 
   @override
-  State<StatefulWidget> createState() => SettingsPageState();
+  State<StatefulWidget> createState() => _SettingsPageState();
 }
 
-class SettingsPageState extends State<SettingsPage> {
+class _SettingsPageState extends State<SettingsPage> {
+  // Whether the user verified their email; this can be true, false or null if
+  // the async check hasn't completed yet.
+  bool isVerified;
+
+  @override
+  void initState() {
+    super.initState();
+    Provider.of<AuthProvider>(context, listen: false)
+        .isVerified
+        .then((value) => setState(() => isVerified = value));
+  }
+
   @override
   Widget build(BuildContext context) {
     final AuthProvider authProvider = Provider.of<AuthProvider>(context);
@@ -109,7 +121,7 @@ class SettingsPageState extends State<SettingsPage> {
                           onPressed: () => {
                             if (authProvider.isAnonymous)
                               {AppToast.show(S.of(context).messageNotLoggedIn)}
-                            else if (!authProvider.isVerifiedFromCache)
+                            else if (isVerified != true)
                               {
                                 AppToast.show(S
                                     .of(context)
@@ -126,7 +138,7 @@ class SettingsPageState extends State<SettingsPage> {
                           child: Text(S.of(context).labelAskPermissions,
                               textAlign: TextAlign.center,
                               style: (authProvider.isAnonymous ||
-                                      !authProvider.isVerifiedFromCache)
+                                      isVerified != true)
                                   ? Theme.of(context).textTheme.bodyText1.apply(
                                         color: Theme.of(context).disabledColor,
                                       )

--- a/lib/pages/settings/view/settings_page.dart
+++ b/lib/pages/settings/view/settings_page.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:acs_upb_mobile/authentication/service/auth_provider.dart';
 import 'package:acs_upb_mobile/generated/l10n.dart';
-import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
+import 'package:acs_upb_mobile/navigation/routes.dart';
 import 'package:acs_upb_mobile/resources/custom_icons.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
 import 'package:acs_upb_mobile/resources/utils.dart';
@@ -129,10 +129,8 @@ class _SettingsPageState extends State<SettingsPage> {
                               }
                             else
                               {
-                                Navigator.of(context).push(
-                                    MaterialPageRoute<RequestPermissionsPage>(
-                                        builder: (_) =>
-                                            RequestPermissionsPage())),
+                                Navigator.of(context)
+                                    .pushNamed(Routes.requestPermissions),
                               }
                           },
                           child: Text(S.of(context).labelAskPermissions,

--- a/lib/pages/timetable/service/uni_event_provider.dart
+++ b/lib/pages/timetable/service/uni_event_provider.dart
@@ -323,7 +323,7 @@ class UniEventProvider extends EventProvider<UniEventInstance>
       final ref =
           FirebaseFirestore.instance.collection('events').doc(event.id);
 
-      if ((await ref.get()).data == null) {
+      if ((await ref.get()).data() == null) {
         print('Event not found.');
         return false;
       }

--- a/lib/pages/timetable/service/uni_event_provider.dart
+++ b/lib/pages/timetable/service/uni_event_provider.dart
@@ -320,8 +320,7 @@ class UniEventProvider extends EventProvider<UniEventInstance>
 
   Future<bool> updateEvent(UniEvent event, {BuildContext context}) async {
     try {
-      final ref =
-          FirebaseFirestore.instance.collection('events').doc(event.id);
+      final ref = FirebaseFirestore.instance.collection('events').doc(event.id);
 
       if ((await ref.get()).data() == null) {
         print('Event not found.');

--- a/lib/pages/timetable/service/uni_event_provider.dart
+++ b/lib/pages/timetable/service/uni_event_provider.dart
@@ -164,11 +164,12 @@ extension AcademicCalendarExtension on AcademicCalendar {
       }).values);
 
   static AcademicCalendar fromSnap(DocumentSnapshot snap) {
+    final data = snap.data();
     return AcademicCalendar(
-      id: snap.documentID,
-      semesters: _eventsFromMapList(snap.data['semesters'], 'semester'),
-      holidays: _eventsFromMapList(snap.data['holidays'], 'holiday'),
-      exams: _eventsFromMapList(snap.data['exams'], 'examSession'),
+      id: snap.id,
+      semesters: _eventsFromMapList(data['semesters'], 'semester'),
+      holidays: _eventsFromMapList(data['holidays'], 'holiday'),
+      exams: _eventsFromMapList(data['exams'], 'examSession'),
     );
   }
 }
@@ -190,9 +191,9 @@ class UniEventProvider extends EventProvider<UniEventInstance>
 
   Future<Map<String, AcademicCalendar>> fetchCalendars() async {
     final QuerySnapshot query =
-        await Firestore.instance.collection('calendars').getDocuments();
-    for (final doc in query.documents) {
-      _calendars[doc.documentID] = AcademicCalendarExtension.fromSnap(doc);
+        await FirebaseFirestore.instance.collection('calendars').get();
+    for (final doc in query.docs) {
+      _calendars[doc.id] = AcademicCalendarExtension.fromSnap(doc);
     }
 
     notifyListeners();
@@ -210,15 +211,17 @@ class UniEventProvider extends EventProvider<UniEventInstance>
   }
 
   Stream<List<UniEvent>> get _events {
-    if (!_authProvider.isAuthenticatedFromCache ||
+    if (!_authProvider.isAuthenticated ||
         _filter == null ||
-        _calendars == null) return Stream.value([]);
+        _calendars == null) {
+      return Stream.value([]);
+    }
 
     final streams = <Stream<List<UniEvent>>>[];
 
     if (_filter.relevantNodes.length > 1) {
       for (final classId in _classIds ?? []) {
-        final Stream<List<UniEvent>> stream = Firestore.instance
+        final Stream<List<UniEvent>> stream = FirebaseFirestore.instance
             .collection('events')
             .where('class', isEqualTo: classId)
             .where('degree', isEqualTo: _filter.baseNode)
@@ -229,14 +232,15 @@ class UniEventProvider extends EventProvider<UniEventInstance>
           final events = <UniEvent>[];
 
           try {
-            for (final doc in snapshot.documents) {
+            for (final doc in snapshot.docs) {
               ClassHeader classHeader;
-              if (doc.data['class'] != null) {
+              final data = doc.data();
+              if (data['class'] != null) {
                 classHeader =
-                    await _classProvider.fetchClassHeader(doc.data['class']);
+                    await _classProvider.fetchClassHeader(data['class']);
               }
 
-              events.add(UniEventExtension.fromJSON(doc.documentID, doc.data,
+              events.add(UniEventExtension.fromJSON(doc.id, data,
                   classHeader: classHeader, calendars: _calendars));
             }
             return events.where((element) => element != null).toList();
@@ -305,7 +309,7 @@ class UniEventProvider extends EventProvider<UniEventInstance>
 
   Future<bool> addEvent(UniEvent event, {BuildContext context}) async {
     try {
-      await Firestore.instance.collection('events').add(event.toData());
+      await FirebaseFirestore.instance.collection('events').add(event.toData());
       notifyListeners();
       return true;
     } catch (e) {
@@ -316,14 +320,15 @@ class UniEventProvider extends EventProvider<UniEventInstance>
 
   Future<bool> updateEvent(UniEvent event, {BuildContext context}) async {
     try {
-      final ref = Firestore.instance.collection('events').document(event.id);
+      final ref =
+          FirebaseFirestore.instance.collection('events').doc(event.id);
 
       if ((await ref.get()).data == null) {
         print('Event not found.');
         return false;
       }
 
-      await ref.updateData(event.toData());
+      await ref.update(event.toData());
       notifyListeners();
       return true;
     } catch (e) {
@@ -335,7 +340,7 @@ class UniEventProvider extends EventProvider<UniEventInstance>
   Future<bool> deleteEvent(UniEvent event, {BuildContext context}) async {
     try {
       DocumentReference ref;
-      ref = Firestore.instance.collection('events').document(event.id);
+      ref = FirebaseFirestore.instance.collection('events').doc(event.id);
       await ref.delete();
       notifyListeners();
       return true;

--- a/lib/pages/timetable/view/timetable_page.dart
+++ b/lib/pages/timetable/view/timetable_page.dart
@@ -268,7 +268,7 @@ class _TimetablePageState extends State<TimetablePage> {
               // Push the Permissions page
               if (authProvider.isAnonymous) {
                 AppToast.show(S.of(context).messageNotLoggedIn);
-              } else if (!authProvider.isVerifiedFromCache) {
+              } else if (await authProvider.isVerified) {
                 AppToast.show(
                     S.of(context).messageEmailNotVerifiedToPerformAction);
               } else {

--- a/lib/pages/timetable/view/timetable_page.dart
+++ b/lib/pages/timetable/view/timetable_page.dart
@@ -6,7 +6,6 @@ import 'package:acs_upb_mobile/pages/classes/view/classes_page.dart';
 import 'package:acs_upb_mobile/pages/filter/service/filter_provider.dart';
 import 'package:acs_upb_mobile/pages/filter/view/filter_page.dart';
 import 'package:acs_upb_mobile/pages/settings/service/request_provider.dart';
-import 'package:acs_upb_mobile/pages/settings/view/request_permissions.dart';
 import 'package:acs_upb_mobile/pages/timetable/model/events/uni_event.dart';
 import 'package:acs_upb_mobile/pages/timetable/service/uni_event_provider.dart';
 import 'package:acs_upb_mobile/pages/timetable/view/date_header.dart';
@@ -263,18 +262,19 @@ class _TimetablePageState extends State<TimetablePage> {
             text: S.of(context).actionRequestPermissions,
             width: 130,
             onTap: () async {
+              // Check if user is verified
+              final bool isVerified = await authProvider.isVerified;
               // Pop the dialog
               Navigator.of(context).pop();
               // Push the Permissions page
               if (authProvider.isAnonymous) {
                 AppToast.show(S.of(context).messageNotLoggedIn);
-              } else if (await authProvider.isVerified) {
+              } else if (!isVerified) {
                 AppToast.show(
                     S.of(context).messageEmailNotVerifiedToPerformAction);
               } else {
-                await Navigator.of(context).push(
-                    MaterialPageRoute<RequestPermissionsPage>(
-                        builder: (_) => RequestPermissionsPage()));
+                await Navigator.of(context)
+                    .pushNamed(Routes.requestPermissions);
               }
             },
           )

--- a/lib/resources/storage/mobile_storage.dart
+++ b/lib/resources/storage/mobile_storage.dart
@@ -18,11 +18,10 @@ class StorageProvider {
   static Future<bool> uploadImage(
       BuildContext context, Uint8List file, String ref) async {
     try {
-      final StorageReference reference =
-          FirebaseStorage.instance.ref().child(ref);
+      final Reference reference = FirebaseStorage.instance.ref().child(ref);
       bool result = false;
-      final StorageUploadTask uploadTask = reference.putData(file);
-      await uploadTask.onComplete.whenComplete(() => result = true).catchError(
+      final UploadTask uploadTask = reference.putData(file);
+      await uploadTask.whenComplete(() => result = true).catchError(
           (dynamic error) =>
               print('Mobile_Storage - StorageUploadTask - uploadImage $error'));
       return result;

--- a/lib/widgets/scaffold.dart
+++ b/lib/widgets/scaffold.dart
@@ -104,7 +104,7 @@ class AppScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     final authProvider = Provider.of<AuthProvider>(context);
     final bool isAuthenticated =
-        authProvider.isAuthenticatedFromCache && !authProvider.isAnonymous;
+        authProvider.isAuthenticated && !authProvider.isAnonymous;
     final bool enableContent = !needsToBeAuthenticated || isAuthenticated;
 
     return GestureDetector(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   built_collection:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.1"
   characters:
     dependency: transitive
     description:
@@ -133,21 +133,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "0.14.3+1"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "2.2.0"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.2.1+1"
   code_builder:
     dependency: transitive
     description:
@@ -268,12 +268,12 @@ packages:
     source: hosted
     version: "5.2.1"
   firebase:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: firebase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.2"
+    version: "7.3.3"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -301,49 +301,63 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.5+3"
+    version: "0.18.3+1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "2.1.3"
   firebase_auth_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3+1"
+    version: "0.3.2+1"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.5.2+1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.2.1+1"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "5.1.0"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   fixnum:
     dependency: transitive
     description:
@@ -802,7 +816,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.8"
+    version: "0.9.9"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -505,12 +505,12 @@ packages:
     source: hosted
     version: "0.1.0+1"
   intl:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0-nullsafety.2"
   intl_translation:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.4+7
+version: 1.2.5+1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -32,7 +32,7 @@ dependencies:
   cached_network_image: ^2.0.0
 
   # Firebase Firestore
-  cloud_firestore: ^0.13.4
+  cloud_firestore: ^0.14.3+1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -51,12 +51,10 @@ dependencies:
   dynamic_theme: ^1.0.1
 
   # Firebase products
-  firebase:
   firebase_analytics: ^5.0.2
-  firebase_auth: ^0.15.5+2
-  firebase_auth_web: ^0.1.2
-  firebase_core: ^0.4.3+1
-  firebase_storage: ^3.1.3
+  firebase_auth: ^0.18.3+1
+  firebase_core: ^0.5.2+1
+  firebase_storage: ^5.1.0
 
   # Flutter SDK
   flutter:

--- a/test/authentication_test.dart
+++ b/test/authentication_test.dart
@@ -56,19 +56,17 @@ void main() {
     mockAuthProvider = MockAuthProvider();
     // ignore: invalid_use_of_protected_member
     when(mockAuthProvider.hasListeners).thenReturn(false);
-    when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(false);
-    when(mockAuthProvider.isAuthenticatedFromService)
-        .thenAnswer((realInvocation) => Future.value(false));
+    when(mockAuthProvider.isAuthenticated).thenReturn(false);
     when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(null));
     when(mockAuthProvider.isAnonymous).thenReturn(true);
     when(mockAuthProvider.getProfilePictureURL(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(null));
+        .thenAnswer((_) => Future.value(null));
 
     mockWebsiteProvider = MockWebsiteProvider();
     // ignore: invalid_use_of_protected_member
     when(mockWebsiteProvider.hasListeners).thenReturn(false);
     when(mockWebsiteProvider.deleteWebsite(any, context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(true));
+        .thenAnswer((_) => Future.value(true));
     when(mockWebsiteProvider.fetchWebsites(any, context: anyNamed('context')))
         .thenAnswer((_) => Future.value([]));
     when(mockWebsiteProvider.fetchFavouriteWebsites(
@@ -94,17 +92,17 @@ void main() {
     // ignore: invalid_use_of_protected_member
     when(mockQuestionProvider.hasListeners).thenReturn(false);
     when(mockQuestionProvider.fetchQuestions(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(<Question>[]));
+        .thenAnswer((_) => Future.value(<Question>[]));
     when(mockQuestionProvider.fetchQuestions(limit: anyNamed('limit')))
-        .thenAnswer((realInvocation) => Future.value(<Question>[]));
+        .thenAnswer((_) => Future.value(<Question>[]));
 
     mockNewsProvider = MockNewsProvider();
     // ignore: invalid_use_of_protected_member
     when(mockNewsProvider.hasListeners).thenReturn(false);
     when(mockNewsProvider.fetchNewsFeedItems(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[]));
+        .thenAnswer((_) => Future.value(<NewsFeedItem>[]));
     when(mockNewsProvider.fetchNewsFeedItems(limit: anyNamed('limit')))
-        .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[]));
+        .thenAnswer((_) => Future.value(<NewsFeedItem>[]));
   });
 
   group('Login', () {
@@ -398,7 +396,7 @@ void main() {
               info: anyNamed('info'), context: anyNamed('context')))
           .thenAnswer((_) => Future.value(true));
       when(mockAuthProvider.canSignUpWithEmail(email: anyNamed('email')))
-          .thenAnswer((realInvocation) => Future.value(true));
+          .thenAnswer((_) => Future.value(true));
 
       // Test parser from email
       final Finder email = find.byKey(const ValueKey('email_text_field'));
@@ -567,16 +565,12 @@ void main() {
 
     setUp(() {
       // Mock an anonymous user already being logged in
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
-      when(mockAuthProvider.isAuthenticatedFromService)
-          .thenAnswer((realInvocation) => Future.value(true));
-      when(mockAuthProvider.isVerifiedFromService)
-          .thenAnswer((realInvocation) => Future.value(false));
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
+      when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(false));
     });
 
     testWidgets('Sign out anonymous', (WidgetTester tester) async {
-      when(mockAuthProvider.currentUser)
-          .thenAnswer((realInvocation) => Future.value(null));
+      when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(null));
       when(mockAuthProvider.currentUserFromCache).thenReturn(null);
       when(mockAuthProvider.isAnonymous).thenReturn(true);
 
@@ -608,7 +602,7 @@ void main() {
     });
 
     testWidgets('Sign out authenticated', (WidgetTester tester) async {
-      when(mockAuthProvider.currentUser).thenAnswer((realInvocation) =>
+      when(mockAuthProvider.currentUser).thenAnswer((_) =>
           Future.value(User(uid: '0', firstName: 'John', lastName: 'Doe')));
       when(mockAuthProvider.currentUserFromCache)
           .thenReturn(User(uid: '0', firstName: 'John', lastName: 'Doe'));

--- a/test/firebase_mock.dart
+++ b/test/firebase_mock.dart
@@ -1,0 +1,45 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// Source: https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_auth/firebase_auth/test/mock.dart
+
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+typedef Callback(MethodCall call);
+
+setupFirebaseAuthMocks([Callback /*?*/ customHandlers]) {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
+    if (call.method == 'Firebase#initializeCore') {
+      return [
+        {
+          'name': defaultFirebaseAppName,
+          'options': {
+            'apiKey': '123',
+            'appId': '123',
+            'messagingSenderId': '123',
+            'projectId': '123',
+          },
+          'pluginConstants': {},
+        }
+      ];
+    }
+
+    if (call.method == 'Firebase#initializeApp') {
+      return {
+        'name': call.arguments['appName'],
+        'options': call.arguments['options'],
+        'pluginConstants': {},
+      };
+    }
+
+    if (customHandlers != null) {
+      customHandlers(call);
+    }
+
+    return null;
+  });
+}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -40,6 +40,7 @@ import 'package:acs_upb_mobile/pages/timetable/view/timetable_page.dart';
 import 'package:acs_upb_mobile/resources/custom_icons.dart';
 import 'package:acs_upb_mobile/resources/locale_provider.dart';
 import 'package:acs_upb_mobile/widgets/search_bar.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -49,6 +50,7 @@ import 'package:provider/provider.dart';
 import 'package:rrule/rrule.dart';
 import 'package:time_machine/time_machine.dart' hide Offset;
 
+import 'firebase_mock.dart';
 import 'test_utils.dart';
 
 // These tests open each page in the app on multiple screen sizes to make sure
@@ -74,7 +76,7 @@ class MockRequestProvider extends Mock implements RequestProvider {}
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
-void main() {
+Future<void> main() async {
   AuthProvider mockAuthProvider;
   WebsiteProvider mockWebsiteProvider;
   FilterProvider mockFilterProvider;
@@ -84,6 +86,9 @@ void main() {
   MockNewsProvider mockNewsProvider;
   UniEventProvider mockEventProvider;
   RequestProvider mockRequestProvider;
+
+  setupFirebaseAuthMocks();
+  await Firebase.initializeApp();
 
   // Test layout for different screen sizes
   // TODO(AdrianMargineanu): Use Flutter driver for integration tests, setting screen sizes here isn't reliable
@@ -127,6 +132,8 @@ void main() {
     PrefService.enableCaching();
     PrefService.cache = {};
     PrefService.setString('language', 'en');
+
+    await Firebase.initializeApp();
 
     LocaleProvider.cultures = testCultures;
     LocaleProvider.rruleL10ns = {'en': await RruleL10nTest.create()};

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -145,6 +145,7 @@ Future<void> main() async {
     when(mockAuthProvider.hasListeners).thenReturn(false);
     when(mockAuthProvider.isAnonymous).thenReturn(true);
     when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(null));
+    when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(false));
 
     mockWebsiteProvider = MockWebsiteProvider();
     // ignore: invalid_use_of_protected_member

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -133,22 +133,19 @@ void main() {
 
     // Pretend an anonymous user is already logged in
     mockAuthProvider = MockAuthProvider();
-    when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+    when(mockAuthProvider.isAuthenticated).thenReturn(true);
     // ignore: invalid_use_of_protected_member
     when(mockAuthProvider.hasListeners).thenReturn(false);
     when(mockAuthProvider.isAnonymous).thenReturn(true);
-    when(mockAuthProvider.isAuthenticatedFromService)
-        .thenAnswer((_) => Future.value(true));
-    when(mockAuthProvider.currentUser)
-        .thenAnswer((realInvocation) => Future.value(null));
+    when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(null));
 
     mockWebsiteProvider = MockWebsiteProvider();
     // ignore: invalid_use_of_protected_member
     when(mockWebsiteProvider.hasListeners).thenReturn(false);
     when(mockWebsiteProvider.deleteWebsite(any, context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(true));
+        .thenAnswer((_) => Future.value(true));
     when(mockAuthProvider.getProfilePictureURL(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(null));
+        .thenAnswer((_) => Future.value(null));
     when(mockWebsiteProvider.fetchWebsites(any, context: anyNamed('context')))
         .thenAnswer((_) => Future.value([
               Website(
@@ -394,7 +391,7 @@ void main() {
     // ignore: invalid_use_of_protected_member
     when(mockQuestionProvider.hasListeners).thenReturn(false);
     when(mockQuestionProvider.fetchQuestions(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(<Question>[
+        .thenAnswer((_) => Future.value(<Question>[
               Question(
                   question: 'Care este programul la secretariat?',
                   answer:
@@ -407,7 +404,7 @@ void main() {
                   tags: ['Conectare', 'Informații'])
             ]));
     when(mockQuestionProvider.fetchQuestions(limit: anyNamed('limit')))
-        .thenAnswer((realInvocation) => Future.value(<Question>[
+        .thenAnswer((_) => Future.value(<Question>[
               Question(
                   question: 'Care este programul la secretariat?',
                   answer:
@@ -424,7 +421,7 @@ void main() {
     // ignore: invalid_use_of_protected_member
     when(mockNewsProvider.hasListeners).thenReturn(false);
     when(mockNewsProvider.fetchNewsFeedItems(context: anyNamed('context')))
-        .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[
+        .thenAnswer((_) => Future.value(<NewsFeedItem>[
               NewsFeedItem(
                   '03.10.2020',
                   'Cazarea studentilor de anul II licenta',
@@ -435,7 +432,7 @@ void main() {
                   'https://acs.pub.ro/noutati/festivitatea-de-deschidere-a-anului-universitar-2020-2021/')
             ]));
     when(mockNewsProvider.fetchNewsFeedItems(limit: anyNamed('limit')))
-        .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[
+        .thenAnswer((_) => Future.value(<NewsFeedItem>[
               NewsFeedItem(
                   '03.10.2020',
                   'Cazarea studentilor de anul II licenta',
@@ -656,9 +653,7 @@ void main() {
           uid: '0', firstName: 'John', lastName: 'Doe', permissionLevel: 3)));
       when(mockAuthProvider.currentUserFromCache).thenReturn(User(
           uid: '0', firstName: 'John', lastName: 'Doe', permissionLevel: 3));
-      when(mockAuthProvider.isAuthenticatedFromService)
-          .thenAnswer((_) => Future.value(true));
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(false);
       when(mockAuthProvider.uid).thenReturn('0');
     });
@@ -738,7 +733,7 @@ void main() {
         when(mockAuthProvider.currentUserFromCache).thenReturn(User(
             uid: '0', firstName: 'John', lastName: 'Doe', permissionLevel: 0));
         when(mockAuthProvider.isAnonymous).thenReturn(false);
-        when(mockAuthProvider.isVerifiedFromCache).thenReturn(true);
+        when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
 
         when(mockEventProvider.getAllDayEventsIntersecting(any))
             .thenAnswer((_) => Stream.value([]));
@@ -1106,9 +1101,7 @@ void main() {
             Future.value(User(uid: '0', firstName: 'John', lastName: 'Doe')));
         when(mockAuthProvider.currentUserFromCache)
             .thenReturn(User(uid: '0', firstName: 'John', lastName: 'Doe'));
-        when(mockAuthProvider.isAuthenticatedFromService)
-            .thenAnswer((_) => Future.value(true));
-        when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+        when(mockAuthProvider.isAuthenticated).thenReturn(true);
         when(mockAuthProvider.isAnonymous).thenReturn(false);
         when(mockAuthProvider.uid).thenReturn('0');
       });
@@ -1141,9 +1134,7 @@ void main() {
             Future.value(User(uid: '0', firstName: 'John', lastName: 'Doe')));
         when(mockAuthProvider.currentUserFromCache)
             .thenReturn(User(uid: '0', firstName: 'John', lastName: 'Doe'));
-        when(mockAuthProvider.isAuthenticatedFromService)
-            .thenAnswer((_) => Future.value(true));
-        when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+        when(mockAuthProvider.isAuthenticated).thenReturn(true);
         when(mockAuthProvider.isAnonymous).thenReturn(false);
         when(mockAuthProvider.uid).thenReturn('0');
       });
@@ -1185,9 +1176,7 @@ void main() {
             uid: '0', firstName: 'John', lastName: 'Doe', permissionLevel: 3)));
         when(mockAuthProvider.currentUserFromCache).thenReturn(User(
             uid: '0', firstName: 'John', lastName: 'Doe', permissionLevel: 3));
-        when(mockAuthProvider.isAuthenticatedFromService)
-            .thenAnswer((_) => Future.value(true));
-        when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+        when(mockAuthProvider.isAuthenticated).thenReturn(true);
         when(mockAuthProvider.isAnonymous).thenReturn(false);
         when(mockAuthProvider.uid).thenReturn('0');
       });
@@ -1299,7 +1288,7 @@ void main() {
 
   group('Add website', () {
     setUp(() {
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(false);
     });
 
@@ -1330,14 +1319,10 @@ void main() {
 
   group('Edit website', () {
     setUp(() {
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(false);
-      when(mockAuthProvider.currentUser).thenAnswer((realInvocation) =>
-          Future.value(User(
-              uid: '1',
-              firstName: 'John',
-              lastName: 'Doe',
-              permissionLevel: 3)));
+      when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(User(
+          uid: '1', firstName: 'John', lastName: 'Doe', permissionLevel: 3)));
     });
 
     for (final size in screenSizes) {
@@ -1369,14 +1354,10 @@ void main() {
 
   group('Delete website', () {
     setUp(() {
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(false);
-      when(mockAuthProvider.currentUser).thenAnswer((realInvocation) =>
-          Future.value(User(
-              uid: '1',
-              firstName: 'John',
-              lastName: 'Doe',
-              permissionLevel: 3)));
+      when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(User(
+          uid: '1', firstName: 'John', lastName: 'Doe', permissionLevel: 3)));
     });
 
     for (final size in screenSizes) {
@@ -1435,20 +1416,16 @@ void main() {
   });
   group('Edit Profile', () {
     setUp(() {
-      when(mockAuthProvider.isVerifiedFromCache).thenReturn(false);
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(false));
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(false);
-      when(mockAuthProvider.currentUser).thenAnswer((realInvocation) =>
-          Future.value(User(
-              uid: '1',
-              firstName: 'John',
-              lastName: 'Doe',
-              permissionLevel: 3)));
+      when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(User(
+          uid: '1', firstName: 'John', lastName: 'Doe', permissionLevel: 3)));
       when(mockAuthProvider.currentUserFromCache).thenReturn(User(
           uid: '1', firstName: 'John', lastName: 'Doe', permissionLevel: 3));
       when(mockAuthProvider.email).thenReturn('john.doe@stud.acs.upb.ro');
       when(mockAuthProvider.getProfilePictureURL(context: anyNamed('context')))
-          .thenAnswer((realInvocation) => Future.value(null));
+          .thenAnswer((_) => Future.value(null));
     });
 
     for (final size in screenSizes) {
@@ -1536,7 +1513,7 @@ void main() {
 
   group('People page', () {
     setUp(() {
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       when(mockAuthProvider.isAnonymous).thenReturn(true);
     });
 

--- a/test/portal_test.dart
+++ b/test/portal_test.dart
@@ -78,18 +78,15 @@ void main() {
 
   final MockUrlLauncher mockUrlLauncher = MockUrlLauncher();
   UrlLauncherPlatform.instance = mockUrlLauncher;
-  when(mockUrlLauncher.canLaunch(any))
-      .thenAnswer((realInvocation) => Future.value(true));
+  when(mockUrlLauncher.canLaunch(any)).thenAnswer((_) => Future.value(true));
 
   final MockAuthProvider mockAuthProvider = MockAuthProvider();
   // ignore: invalid_use_of_protected_member
   when(mockAuthProvider.hasListeners).thenReturn(false);
   when(mockAuthProvider.isAnonymous).thenReturn(false);
-  when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
-  when(mockAuthProvider.isAuthenticatedFromService)
-      .thenAnswer((realInvocation) => Future.value(true));
-  when(mockAuthProvider.currentUser).thenAnswer((realInvocation) =>
-      Future.value(User(uid: '0', firstName: 'John', lastName: 'Doe')));
+  when(mockAuthProvider.isAuthenticated).thenReturn(true);
+  when(mockAuthProvider.currentUser).thenAnswer(
+      (_) => Future.value(User(uid: '0', firstName: 'John', lastName: 'Doe')));
   when(mockAuthProvider.currentUserFromCache)
       .thenReturn(User(uid: '0', firstName: 'John', lastName: 'Doe'));
 

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -50,21 +50,19 @@ void main() {
 
       // Pretend an anonymous user is already logged in
       mockAuthProvider = MockAuthProvider();
-      when(mockAuthProvider.isAuthenticatedFromCache).thenReturn(true);
+      when(mockAuthProvider.isAuthenticated).thenReturn(true);
       // ignore: invalid_use_of_protected_member
       when(mockAuthProvider.hasListeners).thenReturn(false);
-      when(mockAuthProvider.isAuthenticatedFromService)
-          .thenAnswer((realInvocation) => Future.value(true));
       when(mockAuthProvider.currentUser).thenAnswer((_) => Future.value(null));
       when(mockAuthProvider.isAnonymous).thenReturn(true);
       when(mockAuthProvider.getProfilePictureURL(context: anyNamed('context')))
-          .thenAnswer((realInvocation) => Future.value(null));
+          .thenAnswer((_) => Future.value(null));
 
       mockWebsiteProvider = MockWebsiteProvider();
       // ignore: invalid_use_of_protected_member
       when(mockWebsiteProvider.hasListeners).thenReturn(false);
       when(mockWebsiteProvider.deleteWebsite(any, context: anyNamed('context')))
-          .thenAnswer((realInvocation) => Future.value(true));
+          .thenAnswer((_) => Future.value(true));
       when(mockWebsiteProvider.fetchWebsites(any, context: anyNamed('context')))
           .thenAnswer((_) => Future.value([]));
       when(mockWebsiteProvider.fetchFavouriteWebsites(
@@ -75,9 +73,9 @@ void main() {
       // ignore: invalid_use_of_protected_member
       when(mockQuestionProvider.hasListeners).thenReturn(false);
       when(mockQuestionProvider.fetchQuestions(context: anyNamed('context')))
-          .thenAnswer((realInvocation) => Future.value(<Question>[]));
+          .thenAnswer((_) => Future.value(<Question>[]));
       when(mockQuestionProvider.fetchQuestions(limit: anyNamed('limit')))
-          .thenAnswer((realInvocation) => Future.value(<Question>[]));
+          .thenAnswer((_) => Future.value(<Question>[]));
 
       mockRequestProvider = MockRequestProvider();
       when(mockRequestProvider.makeRequest(any, context: anyNamed('context')))
@@ -90,9 +88,9 @@ void main() {
       // ignore: invalid_use_of_protected_member
       when(mockNewsProvider.hasListeners).thenReturn(false);
       when(mockNewsProvider.fetchNewsFeedItems(context: anyNamed('context')))
-          .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[]));
+          .thenAnswer((_) => Future.value(<NewsFeedItem>[]));
       when(mockNewsProvider.fetchNewsFeedItems(limit: anyNamed('limit')))
-          .thenAnswer((realInvocation) => Future.value(<NewsFeedItem>[]));
+          .thenAnswer((_) => Future.value(<NewsFeedItem>[]));
     });
 
     testWidgets('Dark Mode', (WidgetTester tester) async {
@@ -183,7 +181,7 @@ void main() {
       });
 
       testWidgets('Normal scenario', (WidgetTester tester) async {
-        when(mockAuthProvider.isVerifiedFromCache).thenAnswer((_) => true);
+        when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
 
         await tester.pumpWidget(MultiProvider(providers: [
           ChangeNotifierProvider<AuthProvider>(create: (_) => mockAuthProvider),
@@ -221,7 +219,7 @@ void main() {
 
       testWidgets('User has already sent a request scenario',
           (WidgetTester tester) async {
-        when(mockAuthProvider.isVerifiedFromCache).thenAnswer((_) => true);
+        when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
         when(mockRequestProvider.userAlreadyRequested(any,
                 context: anyNamed('context')))
             .thenAnswer((_) => Future.value(true));
@@ -266,7 +264,7 @@ void main() {
       });
 
       testWidgets('User is anonymous scenario', (WidgetTester tester) async {
-        when(mockAuthProvider.isVerifiedFromCache).thenAnswer((_) => true);
+        when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
         when(mockAuthProvider.isAnonymous).thenReturn(true);
         when(mockRequestProvider.userAlreadyRequested(any,
                 context: anyNamed('context')))
@@ -297,7 +295,8 @@ void main() {
       });
 
       testWidgets('User is not verified scenario', (WidgetTester tester) async {
-        when(mockAuthProvider.isVerifiedFromCache).thenAnswer((_) => false);
+        when(mockAuthProvider.isVerified)
+            .thenAnswer((_) => Future.value(false));
         when(mockAuthProvider.isAnonymous).thenReturn(false);
         when(mockRequestProvider.userAlreadyRequested(any,
                 context: anyNamed('context')))
@@ -327,7 +326,7 @@ void main() {
         expect(find.byType(SettingsPage), findsOneWidget);
 
         // Verify account
-        when(mockAuthProvider.isVerifiedFromCache).thenAnswer((_) => true);
+        when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
 
         // Press Ask Permissions page
         expect(find.text('Request editing permissions'), findsOneWidget);

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -57,6 +57,7 @@ void main() {
       when(mockAuthProvider.isAnonymous).thenReturn(true);
       when(mockAuthProvider.getProfilePictureURL(context: anyNamed('context')))
           .thenAnswer((_) => Future.value(null));
+      when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
 
       mockWebsiteProvider = MockWebsiteProvider();
       // ignore: invalid_use_of_protected_member
@@ -324,9 +325,16 @@ void main() {
         // Verify Ask Permissions page is not opened
         await tester.pumpAndSettle(const Duration(seconds: 4));
         expect(find.byType(SettingsPage), findsOneWidget);
+        expect(find.byType(RequestPermissionsPage), findsNothing);
 
         // Verify account
         when(mockAuthProvider.isVerified).thenAnswer((_) => Future.value(true));
+
+        // Go back and open settings again
+        await tester.tap(find.byIcon(Icons.arrow_back));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.settings));
+        await tester.pumpAndSettle();
 
         // Press Ask Permissions page
         expect(find.text('Request editing permissions'), findsOneWidget);


### PR DESCRIPTION
Followed the FlutterFire [migration guide](https://firebase.flutter.dev/docs/migration/) to use the new firebase_core and associated plugins. Did some testing to check if everything still works, and fixed some other bugs along the way and made minor improvements:

- [x] Only show profile card and favourite websites card on home page if user is authenticated
- [x] Fix delete() being called twice when deleting account
- [x] Improve position of progress indicator on signup screen
- [x] Stop setting Firebase displayName, we're not using it anyway
- [x] Fix "Something went wrong" toast on signup
- [x] Check if user data exists in website provider
