### PR TITLE
Fix default relevance picker not being set.

### DIFF
--- a/lib/pages/filter/service/filter_provider.dart
+++ b/lib/pages/filter/service/filter_provider.dart
@@ -141,7 +141,7 @@ class FilterProvider with ChangeNotifier {
       }
 
       // Check if there is an existing setting already
-      if (global &&
+      if (_authProvider != null &&
           _authProvider.isAuthenticated &&
           !_authProvider.isAnonymous) {
         final userSnap =
@@ -152,6 +152,7 @@ class FilterProvider with ChangeNotifier {
         _relevanceFilter?.setRelevantNodes(_relevantNodes);
       }
 
+      notifyListeners();
       return cachedFilter;
     } catch (e, _) {
       print(e);

--- a/lib/pages/portal/view/portal_page.dart
+++ b/lib/pages/portal/view/portal_page.dart
@@ -344,19 +344,24 @@ class _AddWebsiteButton extends StatelessWidget {
             if (authProvider.isAuthenticated && !authProvider.isAnonymous) {
               Navigator.of(context)
                   .push(MaterialPageRoute<ChangeNotifierProvider>(
-                builder: (_) => ChangeNotifierProvider<FilterProvider>(
-                    create: (_) =>
-                        Platform.environment.containsKey('FLUTTER_TEST')
-                            ? Provider.of<FilterProvider>(context)
-                            : FilterProvider(),
-                    child: WebsiteView(
-                      website: Website(
-                          relevance: null,
-                          id: null,
-                          isPrivate: true,
-                          link: '',
-                          category: category),
-                    )),
+                builder: (_) =>
+                    ChangeNotifierProxyProvider<AuthProvider, FilterProvider>(
+                  create: (_) =>
+                      Platform.environment.containsKey('FLUTTER_TEST')
+                          ? Provider.of<FilterProvider>(context)
+                          : FilterProvider(),
+                  update: (context, authProvider, filterProvider) {
+                    return filterProvider..updateAuth(authProvider);
+                  },
+                  child: WebsiteView(
+                    website: Website(
+                        relevance: null,
+                        id: null,
+                        isPrivate: true,
+                        link: '',
+                        category: category),
+                  ),
+                ),
               ));
             } else {
               AppToast.show(S.of(context).warningAuthenticationNeeded);

--- a/lib/pages/timetable/view/timetable_page.dart
+++ b/lib/pages/timetable/view/timetable_page.dart
@@ -103,8 +103,12 @@ class _TimetablePageState extends State<TimetablePage> {
                     .currentUserFromCache;
                 if (user.canAddPublicInfo) {
                   Navigator.of(context).push(MaterialPageRoute<AddEventView>(
-                    builder: (_) => ChangeNotifierProvider<FilterProvider>(
+                    builder: (_) => ChangeNotifierProxyProvider<AuthProvider,
+                        FilterProvider>(
                       create: (_) => FilterProvider(),
+                      update: (context, authProvider, filterProvider) {
+                        return filterProvider..updateAuth(authProvider);
+                      },
                       child: AddEventView(
                         initialEvent: UniEvent(
                             start: dateTime,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.5+2
+version: 1.2.5+3
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.5+1
+version: 1.2.5+2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
The default relevance should automatically be set to the
user's group or the global filter settings. We probably
broke it when we started saving the filter to Firebase.

I fixed it by fetching the filter in Firebase by default
(even for non-global filters). It's still not perfect,
sometimes in the add event page nothing shows in the
relevance picker and I'm not sure why, but if you press
on Custom, it's automatically set to the current filter
options.