### PR TITLE
Moved the week type calculation after the semester one

### DIFF
--- a/lib/pages/timetable/view/events/add_event_view.dart
+++ b/lib/pages/timetable/view/events/add_event_view.dart
@@ -121,6 +121,7 @@ class _AddEventViewState extends State<AddEventView> {
           selectedSemester = 2;
         }
       }
+
       if (widget.initialEvent != null &&
           widget.initialEvent is RecurringUniEvent) {
         final RecurringUniEvent event = widget.initialEvent;

--- a/lib/pages/timetable/view/events/add_event_view.dart
+++ b/lib/pages/timetable/view/events/add_event_view.dart
@@ -90,24 +90,6 @@ class _AddEventViewState extends State<AddEventView> {
         selectedCalendar = calendars.keys.first;
       });
 
-      if (widget.initialEvent != null &&
-          widget.initialEvent is RecurringUniEvent) {
-        final RecurringUniEvent event = widget.initialEvent;
-        if (event.rrule.interval != 1) {
-          final rule = WeekYearRules.iso;
-          if (rule.getWeekOfWeekYear(semester.start.calendarDate) ==
-              rule.getWeekOfWeekYear(event.start.calendarDate)) {
-            // Week is odd
-            weekSelected[WeekType.even] = false;
-            weekSelected[WeekType.odd] = true;
-          } else {
-            // Week is even
-            weekSelected[WeekType.even] = true;
-            weekSelected[WeekType.odd] = false;
-          }
-        }
-      }
-
       if (widget.initialEvent?.id != null) {
         selectedCalendar = widget.initialEvent.calendar.id;
         final AllDayUniEvent secondSemester =
@@ -139,7 +121,23 @@ class _AddEventViewState extends State<AddEventView> {
           selectedSemester = 2;
         }
       }
-
+      if (widget.initialEvent != null &&
+          widget.initialEvent is RecurringUniEvent) {
+        final RecurringUniEvent event = widget.initialEvent;
+        if (event.rrule.interval != 1) {
+          final rule = WeekYearRules.iso;
+          if (rule.getWeekOfWeekYear(semester.start.calendarDate) ==
+              rule.getWeekOfWeekYear(event.start.calendarDate)) {
+            // Week is odd
+            weekSelected[WeekType.even] = false;
+            weekSelected[WeekType.odd] = true;
+          } else {
+            // Week is even
+            weekSelected[WeekType.even] = true;
+            weekSelected[WeekType.odd] = false;
+          }
+        }
+      }
       setState(() {
         weekSelected[WeekType.even] ??= true;
         weekSelected[WeekType.odd] ??= true;

--- a/lib/pages/timetable/view/events/add_event_view.dart
+++ b/lib/pages/timetable/view/events/add_event_view.dart
@@ -139,6 +139,7 @@ class _AddEventViewState extends State<AddEventView> {
           }
         }
       }
+
       setState(() {
         weekSelected[WeekType.even] ??= true;
         weekSelected[WeekType.odd] ??= true;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -713,7 +713,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A mobile application for students at ACS UPB.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 # ACS UPB Mobile uses semantic versioning. You can read more in the CONTRIBUTING.md file.
-version: 1.2.5+5
+version: 1.2.5+6
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
The type of the week is calculated based on the semester, and since the semester is now properly calculated **before** the week type, the bug should be fixed (see attached issue).