### PR TITLE
Fixes on packageInfo

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="io.flutter.app.FlutterApplication"
-        android:label="ACS UPB"
+        android:label="ACS UPB Mobile"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/lib/pages/settings/view/settings_page.dart
+++ b/lib/pages/settings/view/settings_page.dart
@@ -146,7 +146,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         ),
                         const Divider(),
                         Text(
-                            '${S.of(context).labelVersion} ${Utils.packageInfo.version}+${(int.parse(Utils.packageInfo.buildNumber) - 10000).toString()}',
+                            '${S.of(context).labelVersion} ${Utils.packageInfo.version}+${(int.parse(Utils.packageInfo.buildNumber) % 10000).toString()}',
                             textAlign: TextAlign.center,
                             style: Theme.of(context).textTheme.bodyText1),
                         const Padding(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -616,13 +616,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
-  package_info:
-    dependency: "direct main"
-    description:
-      name: package_info
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.3+4"
   package_info_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,9 +85,6 @@ dependencies:
   # Displays a custom toast
   oktoast: ^2.3.1+1
 
-  # Allows querying the app version number
-  package_info: ^0.4.0+13
-
   # App information
   package_info_plus: ^0.6.4
 


### PR DESCRIPTION
We had 2 libraries of packageInfo, one of them being outdated and causing errors when was imported, so I deleted everything related to this package. We also had trouble with build number for IOS devices. We make build number modulo 10000, as for the android version we add 10000 to it so that we have a good connection with google play, while IOS build number remains the same. I also changed the app name to "ACS UPB Mobile"